### PR TITLE
Use Arcs instead of Rcs to enable using multiple threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ An example code to synthesize a simple chord:
 ```rust
 // Load the SoundFont.
 let mut sf2 = File::open("TimGM6mb.sf2").unwrap();
-let sound_font = Rc::new(SoundFont::new(&mut sf2).unwrap());
+let sound_font = Arc::new(SoundFont::new(&mut sf2).unwrap());
 
 // Create the synthesizer.
 let settings = SynthesizerSettings::new(44100);
@@ -64,11 +64,11 @@ Another example code to synthesize a MIDI file:
 ```rust
 // Load the SoundFont.
 let mut sf2 = File::open("TimGM6mb.sf2").unwrap();
-let sound_font = Rc::new(SoundFont::new(&mut sf2).unwrap());
+let sound_font = Arc::new(SoundFont::new(&mut sf2).unwrap());
 
 // Load the MIDI file.
 let mut mid = File::open("flourish.mid").unwrap();
-let midi_file = Rc::new(MidiFile::new(&mut mid).unwrap());
+let midi_file = Arc::new(MidiFile::new(&mut mid).unwrap());
 
 // Create the MIDI file sequencer.
 let settings = SynthesizerSettings::new(44100);

--- a/rustysynth/README.md
+++ b/rustysynth/README.md
@@ -19,7 +19,7 @@ An example code to synthesize a simple chord:
 ```rust
 // Load the SoundFont.
 let mut sf2 = File::open("TimGM6mb.sf2").unwrap();
-let sound_font = Rc::new(SoundFont::new(&mut sf2).unwrap());
+let sound_font = Arc::new(SoundFont::new(&mut sf2).unwrap());
 
 // Create the synthesizer.
 let settings = SynthesizerSettings::new(44100);
@@ -44,11 +44,11 @@ Another example code to synthesize a MIDI file:
 ```rust
 // Load the SoundFont.
 let mut sf2 = File::open("TimGM6mb.sf2").unwrap();
-let sound_font = Rc::new(SoundFont::new(&mut sf2).unwrap());
+let sound_font = Arc::new(SoundFont::new(&mut sf2).unwrap());
 
 // Load the MIDI file.
 let mut mid = File::open("flourish.mid").unwrap();
-let midi_file = Rc::new(MidiFile::new(&mut mid).unwrap());
+let midi_file = Arc::new(MidiFile::new(&mut mid).unwrap());
 
 // Create the MIDI file sequencer.
 let settings = SynthesizerSettings::new(44100);

--- a/rustysynth/src/midifile_sequencer.rs
+++ b/rustysynth/src/midifile_sequencer.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use std::cmp;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::midifile::Message;
 use crate::midifile::MidiFile;
@@ -11,7 +11,7 @@ use crate::synthesizer::Synthesizer;
 pub struct MidiFileSequencer {
     synthesizer: Synthesizer,
 
-    midi_file: Option<Rc<MidiFile>>,
+    midi_file: Option<Arc<MidiFile>>,
     play_loop: bool,
 
     block_wrote: usize,
@@ -39,8 +39,8 @@ impl MidiFileSequencer {
         }
     }
 
-    pub fn play(&mut self, midi_file: &Rc<MidiFile>, play_loop: bool) {
-        self.midi_file = Some(Rc::clone(midi_file));
+    pub fn play(&mut self, midi_file: &Arc<MidiFile>, play_loop: bool) {
+        self.midi_file = Some(Arc::clone(midi_file));
         self.play_loop = play_loop;
 
         self.block_wrote = self.synthesizer.block_size as usize;

--- a/rustysynth/src/oscillator.rs
+++ b/rustysynth/src/oscillator.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::loop_mode::LoopMode;
 use crate::synthesizer_settings::SynthesizerSettings;
@@ -14,7 +14,7 @@ use crate::synthesizer_settings::SynthesizerSettings;
 pub(crate) struct Oscillator {
     synthesizer_sample_rate: i32,
 
-    data: Option<Rc<Vec<i16>>>,
+    data: Option<Arc<Vec<i16>>>,
     loop_mode: i32,
     sample_sample_rate: i32,
     start: i32,
@@ -58,7 +58,7 @@ impl Oscillator {
 
     pub(crate) fn start(
         &mut self,
-        data: &Rc<Vec<i16>>,
+        data: &Arc<Vec<i16>>,
         loop_mode: i32,
         sample_rate: i32,
         start: i32,
@@ -70,7 +70,7 @@ impl Oscillator {
         fine_tune: i32,
         scale_tuning: i32,
     ) {
-        self.data = Some(Rc::clone(data));
+        self.data = Some(Arc::clone(data));
         self.loop_mode = loop_mode;
         self.sample_sample_rate = sample_rate;
         self.start = start;

--- a/rustysynth/src/region_ex.rs
+++ b/rustysynth/src/region_ex.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::lfo::Lfo;
 use crate::modulation_envelope::ModulationEnvelope;
@@ -16,7 +16,7 @@ pub(crate) struct RegionEx {}
 impl RegionEx {
     pub(crate) fn start_oscillator(
         oscillator: &mut Oscillator,
-        data: &Rc<Vec<i16>>,
+        data: &Arc<Vec<i16>>,
         region: &RegionPair,
     ) {
         let sample_rate = region.instrument.sample_sample_rate;

--- a/rustysynth/src/soundfont.rs
+++ b/rustysynth/src/soundfont.rs
@@ -2,7 +2,7 @@
 
 use std::error::Error;
 use std::io::Read;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::binary_reader::BinaryReader;
 use crate::instrument::Instrument;
@@ -16,7 +16,7 @@ use crate::soundfont_sampledata::SoundFontSampleData;
 pub struct SoundFont {
     pub(crate) info: SoundFontInfo,
     pub(crate) bits_per_sample: i32,
-    pub(crate) wave_data: Rc<Vec<i16>>,
+    pub(crate) wave_data: Arc<Vec<i16>>,
     pub(crate) sample_headers: Vec<SampleHeader>,
     pub(crate) presets: Vec<Preset>,
     pub(crate) instruments: Vec<Instrument>,
@@ -46,7 +46,7 @@ impl SoundFont {
         Ok(Self {
             info: info,
             bits_per_sample: 16,
-            wave_data: Rc::new(sample_data.wave_data),
+            wave_data: Arc::new(sample_data.wave_data),
             sample_headers: parameters.sample_headers,
             presets: parameters.presets,
             instruments: parameters.instruments,

--- a/rustysynth/src/synthesizer.rs
+++ b/rustysynth/src/synthesizer.rs
@@ -3,7 +3,7 @@
 use std::cmp;
 use std::collections::HashMap;
 use std::error::Error;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::array_math::ArrayMath;
 use crate::channel::Channel;
@@ -17,7 +17,7 @@ use crate::voice_collection::VoiceCollection;
 
 #[non_exhaustive]
 pub struct Synthesizer {
-    pub(crate) sound_font: Rc<SoundFont>,
+    pub(crate) sound_font: Arc<SoundFont>,
     pub(crate) sample_rate: i32,
     pub(crate) block_size: i32,
     pub(crate) maximum_polyphony: i32,
@@ -58,7 +58,7 @@ impl Synthesizer {
     pub const PERCUSSION_CHANNEL: i32 = 9;
 
     pub fn new(
-        sound_font: &Rc<SoundFont>,
+        sound_font: &Arc<SoundFont>,
         settings: &SynthesizerSettings,
     ) -> Result<Self, Box<dyn Error>> {
         settings.validate()?;
@@ -151,7 +151,7 @@ impl Synthesizer {
         };
 
         Ok(Self {
-            sound_font: Rc::clone(sound_font),
+            sound_font: Arc::clone(sound_font),
             sample_rate: settings.sample_rate,
             block_size: settings.block_size,
             maximum_polyphony: settings.maximum_polyphony,

--- a/rustysynth/src/voice.rs
+++ b/rustysynth/src/voice.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use std::f32::consts;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::bi_quad_filter::BiQuadFilter;
 use crate::channel::Channel;
@@ -125,7 +125,7 @@ impl Voice {
 
     pub(crate) fn start(
         &mut self,
-        data: &Rc<Vec<i16>>,
+        data: &Arc<Vec<i16>>,
         region: &RegionPair,
         channel: i32,
         key: i32,

--- a/workspace/src/main.rs
+++ b/workspace/src/main.rs
@@ -5,7 +5,7 @@ use rustysynth::Synthesizer;
 use rustysynth::SynthesizerSettings;
 use std::fs::File;
 use std::io::Write;
-use std::rc::Rc;
+use std::sync::Arc;
 
 fn main() {
     simple_chord();
@@ -15,7 +15,7 @@ fn main() {
 fn simple_chord() {
     // Load the SoundFont.
     let mut sf2 = File::open("TimGM6mb.sf2").unwrap();
-    let sound_font = Rc::new(SoundFont::new(&mut sf2).unwrap());
+    let sound_font = Arc::new(SoundFont::new(&mut sf2).unwrap());
 
     // Create the synthesizer.
     let settings = SynthesizerSettings::new(44100);
@@ -41,11 +41,11 @@ fn simple_chord() {
 fn flourish() {
     // Load the SoundFont.
     let mut sf2 = File::open("TimGM6mb.sf2").unwrap();
-    let sound_font = Rc::new(SoundFont::new(&mut sf2).unwrap());
+    let sound_font = Arc::new(SoundFont::new(&mut sf2).unwrap());
 
     // Load the MIDI file.
     let mut mid = File::open("flourish.mid").unwrap();
-    let midi_file = Rc::new(MidiFile::new(&mut mid).unwrap());
+    let midi_file = Arc::new(MidiFile::new(&mut mid).unwrap());
 
     // Create the MIDI file sequencer.
     let settings = SynthesizerSettings::new(44100);


### PR DESCRIPTION
Hi, this allows using `rustysynth` for live synthesis with [`rodio`](https://lib.rs/rodio), which [requires the audio sources to be `Send`](https://docs.rs/rodio/latest/rodio/struct.OutputStreamHandle.html#method.play_raw).

Thank you for making this library!
