### PR TITLE
Add sample ID getter for instrument region

### DIFF
--- a/rustysynth/src/instrument_region.rs
+++ b/rustysynth/src/instrument_region.rs
@@ -373,4 +373,8 @@ impl InstrumentRegion {
             self.sample_original_pitch
         }
     }
+
+    pub fn get_sample_id(&self) -> i32 {
+        self.gs[GeneratorType::SAMPLE_ID as usize] as i32
+    }
 }


### PR DESCRIPTION
Currently, some information about the sample used by an instrument region (e.g. sample ID, original pitch, sample rate, etc.) are not publicly available (being visible only within the crate). This PR addresses that by providing a way to access the sample directly via the sample ID.