### PR TITLE
fix: Use `read_u32` instead of `read_i32` to prevent wrong size parsing

### DIFF
--- a/rustysynth/src/binary_reader.rs
+++ b/rustysynth/src/binary_reader.rs
@@ -6,6 +6,8 @@ use std::io::Read;
 use std::slice;
 use std::str;
 
+use crate::four_cc::FourCC;
+
 #[allow(unused)]
 #[non_exhaustive]
 pub(crate) struct BinaryReader {}
@@ -75,18 +77,10 @@ impl BinaryReader {
         Ok(acc)
     }
 
-    pub(crate) fn read_four_cc<R: Read>(reader: &mut R) -> Result<String, io::Error> {
+    pub(crate) fn read_four_cc<R: Read>(reader: &mut R) -> Result<FourCC, io::Error> {
         let mut data: [u8; 4] = [0; 4];
         reader.read_exact(&mut data)?;
-
-        // Replace non-ASCII characters with '?'.
-        for value in &mut data {
-            if !(32..=126).contains(value) {
-                *value = 63; // '?'
-            }
-        }
-
-        Ok(str::from_utf8(&data).unwrap().to_string())
+        Ok(FourCC::from_bytes(data))
     }
 
     pub(crate) fn read_fixed_length_string<R: Read>(

--- a/rustysynth/src/binary_reader.rs
+++ b/rustysynth/src/binary_reader.rs
@@ -43,6 +43,12 @@ impl BinaryReader {
         Ok(i32::from_le_bytes(data))
     }
 
+    pub(crate) fn read_u32<R: Read>(reader: &mut R) -> Result<u32, io::Error> {
+        let mut data: [u8; 4] = [0; 4];
+        reader.read_exact(&mut data)?;
+        Ok(u32::from_le_bytes(data))
+    }
+
     pub(crate) fn read_i16_big_endian<R: Read>(reader: &mut R) -> Result<i16, io::Error> {
         let mut data: [u8; 2] = [0; 2];
         reader.read_exact(&mut data)?;

--- a/rustysynth/src/error.rs
+++ b/rustysynth/src/error.rs
@@ -2,6 +2,8 @@ use std::error;
 use std::fmt;
 use std::io;
 
+use crate::four_cc::FourCC;
+
 /// Represents an error when initializing a synthesizer.
 #[derive(Debug)]
 #[non_exhaustive]
@@ -44,18 +46,18 @@ pub enum SoundFontError {
     IoError(io::Error),
     RiffChunkNotFound,
     InvalidRiffChunkType {
-        expected: &'static str,
-        actual: String,
+        expected: FourCC,
+        actual: FourCC,
     },
     ListChunkNotFound,
     InvalidListChunkType {
-        expected: &'static str,
-        actual: String,
+        expected: FourCC,
+        actual: FourCC,
     },
-    ListContainsUnknownId(String),
+    ListContainsUnknownId(FourCC),
     SampleDataNotFound,
     UnsupportedSampleFormat,
-    SubChunkNotFound(&'static str),
+    SubChunkNotFound(FourCC),
     InvalidPresetList,
     InvalidInstrumentId {
         preset_name: String,
@@ -154,11 +156,8 @@ impl From<io::Error> for SoundFontError {
 #[non_exhaustive]
 pub enum MidiFileError {
     IoError(io::Error),
-    InvalidChunkType {
-        expected: &'static str,
-        actual: String,
-    },
-    InvalidChunkData(&'static str),
+    InvalidChunkType { expected: FourCC, actual: FourCC },
+    InvalidChunkData(FourCC),
     UnsupportedFormat(i16),
     InvalidTempoValue,
 }

--- a/rustysynth/src/four_cc.rs
+++ b/rustysynth/src/four_cc.rs
@@ -5,10 +5,11 @@ pub struct FourCC([u8; 4]);
 
 impl FourCC {
     pub(crate) const fn from_bytes(mut bytes: [u8; 4]) -> Self {
-        bytes[0] = replace_if_non_ascii(bytes[0]);
-        bytes[1] = replace_if_non_ascii(bytes[1]);
-        bytes[2] = replace_if_non_ascii(bytes[2]);
-        bytes[3] = replace_if_non_ascii(bytes[3]);
+        // Replace non-ASCII characters with '?'.
+        bytes[0] = replace_with_question_mark_if_non_ascii(bytes[0]);
+        bytes[1] = replace_with_question_mark_if_non_ascii(bytes[1]);
+        bytes[2] = replace_with_question_mark_if_non_ascii(bytes[2]);
+        bytes[3] = replace_with_question_mark_if_non_ascii(bytes[3]);
         Self(bytes)
     }
 
@@ -47,7 +48,7 @@ const fn is_ascii_graphic_or_space(byte: u8) -> bool {
     byte.is_ascii_graphic() || byte == b' '
 }
 
-const fn replace_if_non_ascii(byte: u8) -> u8 {
+const fn replace_with_question_mark_if_non_ascii(byte: u8) -> u8 {
     if is_ascii_graphic_or_space(byte) {
         byte
     } else {

--- a/rustysynth/src/four_cc.rs
+++ b/rustysynth/src/four_cc.rs
@@ -1,0 +1,56 @@
+use std::fmt::{Debug, Display, Formatter, Result, Write};
+
+#[derive(PartialEq, Eq)]
+pub struct FourCC([u8; 4]);
+
+impl FourCC {
+    pub(crate) const fn from_bytes(mut bytes: [u8; 4]) -> Self {
+        bytes[0] = replace_if_non_ascii(bytes[0]);
+        bytes[1] = replace_if_non_ascii(bytes[1]);
+        bytes[2] = replace_if_non_ascii(bytes[2]);
+        bytes[3] = replace_if_non_ascii(bytes[3]);
+        Self(bytes)
+    }
+
+    pub const fn as_bytes(&self) -> &[u8; 4] {
+        &self.0
+    }
+}
+
+impl Display for FourCC {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        for byte in &self.0 {
+            f.write_char(*byte as char)?;
+        }
+        Ok(())
+    }
+}
+
+impl Debug for FourCC {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        f.write_char('"')?;
+        for byte in &self.0 {
+            f.write_char(*byte as char)?;
+        }
+        f.write_char('"')?;
+        Ok(())
+    }
+}
+
+impl PartialEq<[u8; 4]> for FourCC {
+    fn eq(&self, other: &[u8; 4]) -> bool {
+        &self.0 == other
+    }
+}
+
+const fn is_ascii_graphic_or_space(byte: u8) -> bool {
+    byte.is_ascii_graphic() || byte == b' '
+}
+
+const fn replace_if_non_ascii(byte: u8) -> u8 {
+    if is_ascii_graphic_or_space(byte) {
+        byte
+    } else {
+        b'?'
+    }
+}

--- a/rustysynth/src/four_cc.rs
+++ b/rustysynth/src/four_cc.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Debug, Display, Formatter, Result, Write};
 
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 pub struct FourCC([u8; 4]);
 
 impl FourCC {
@@ -35,6 +35,12 @@ impl Debug for FourCC {
         }
         f.write_char('"')?;
         Ok(())
+    }
+}
+
+impl PartialEq<&[u8; 4]> for FourCC {
+    fn eq(&self, other: &&[u8; 4]) -> bool {
+        &self.0 == *other
     }
 }
 

--- a/rustysynth/src/lib.rs
+++ b/rustysynth/src/lib.rs
@@ -2,6 +2,7 @@ mod error;
 
 mod array_math;
 mod binary_reader;
+mod four_cc;
 mod read_counter;
 
 mod generator;

--- a/rustysynth/src/midifile.rs
+++ b/rustysynth/src/midifile.rs
@@ -3,6 +3,7 @@
 use std::io::Read;
 
 use crate::binary_reader::BinaryReader;
+use crate::four_cc::FourCC;
 use crate::read_counter::ReadCounter;
 use crate::MidiFileError;
 use crate::MidiFileLoopType;
@@ -166,16 +167,18 @@ impl MidiFile {
         loop_type: MidiFileLoopType,
     ) -> Result<Self, MidiFileError> {
         let chunk_type = BinaryReader::read_four_cc(reader)?;
-        if chunk_type != "MThd" {
+        if &chunk_type != b"MThd" {
             return Err(MidiFileError::InvalidChunkType {
-                expected: "MThd",
+                expected: FourCC::from_bytes(*b"MThd"),
                 actual: chunk_type,
             });
         }
 
         let size = BinaryReader::read_i32_big_endian(reader)?;
         if size != 6 {
-            return Err(MidiFileError::InvalidChunkData("MThd"));
+            return Err(MidiFileError::InvalidChunkData(FourCC::from_bytes(
+                *b"MThd",
+            )));
         }
 
         let format = BinaryReader::read_i16_big_endian(reader)?;
@@ -246,9 +249,9 @@ impl MidiFile {
         loop_type: MidiFileLoopType,
     ) -> Result<(Vec<Message>, Vec<i32>), MidiFileError> {
         let chunk_type = BinaryReader::read_four_cc(reader)?;
-        if chunk_type != "MTrk" {
+        if &chunk_type != b"MTrk" {
             return Err(MidiFileError::InvalidChunkType {
-                expected: "MTrk",
+                expected: FourCC::from_bytes(*b"MTrk"),
                 actual: chunk_type,
             });
         }

--- a/rustysynth/src/midifile.rs
+++ b/rustysynth/src/midifile.rs
@@ -167,7 +167,7 @@ impl MidiFile {
         loop_type: MidiFileLoopType,
     ) -> Result<Self, MidiFileError> {
         let chunk_type = BinaryReader::read_four_cc(reader)?;
-        if &chunk_type != b"MThd" {
+        if chunk_type != b"MThd" {
             return Err(MidiFileError::InvalidChunkType {
                 expected: FourCC::from_bytes(*b"MThd"),
                 actual: chunk_type,
@@ -249,7 +249,7 @@ impl MidiFile {
         loop_type: MidiFileLoopType,
     ) -> Result<(Vec<Message>, Vec<i32>), MidiFileError> {
         let chunk_type = BinaryReader::read_four_cc(reader)?;
-        if &chunk_type != b"MTrk" {
+        if chunk_type != b"MTrk" {
             return Err(MidiFileError::InvalidChunkType {
                 expected: FourCC::from_bytes(*b"MTrk"),
                 actual: chunk_type,

--- a/rustysynth/src/oscillator.rs
+++ b/rustysynth/src/oscillator.rs
@@ -77,13 +77,7 @@ impl Oscillator {
         self.tune = coarse_tune as f32 + 0.01_f32 * fine_tune as f32;
         self.pitch_change_scale = 0.01_f32 * scale_tuning as f32;
         self.sample_rate_ratio = sample_rate as f32 / self.synthesizer_sample_rate as f32;
-
-        if self.loop_mode == LoopMode::NO_LOOP {
-            self.looping = false;
-        } else {
-            self.looping = true;
-        }
-
+        self.looping = self.loop_mode != LoopMode::NO_LOOP;
         self.position_fp = (start as i64) << Oscillator::FRAC_BITS;
     }
 

--- a/rustysynth/src/soundfont.rs
+++ b/rustysynth/src/soundfont.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use crate::binary_reader::BinaryReader;
 use crate::error::SoundFontError;
+use crate::four_cc::FourCC;
 use crate::instrument::Instrument;
 use crate::preset::Preset;
 use crate::sample_header::SampleHeader;
@@ -31,16 +32,16 @@ impl SoundFont {
     /// * `reader` - The data stream used to load the SoundFont.
     pub fn new<R: Read>(reader: &mut R) -> Result<Self, SoundFontError> {
         let chunk_id = BinaryReader::read_four_cc(reader)?;
-        if chunk_id != "RIFF" {
+        if &chunk_id != b"RIFF" {
             return Err(SoundFontError::RiffChunkNotFound);
         }
 
         let _size = BinaryReader::read_i32(reader);
 
         let form_type = BinaryReader::read_four_cc(reader)?;
-        if form_type != "sfbk" {
+        if &form_type != b"sfbk" {
             return Err(SoundFontError::InvalidRiffChunkType {
-                expected: "sfbk",
+                expected: FourCC::from_bytes(*b"sfbk"),
                 actual: form_type,
             });
         }

--- a/rustysynth/src/soundfont.rs
+++ b/rustysynth/src/soundfont.rs
@@ -32,14 +32,14 @@ impl SoundFont {
     /// * `reader` - The data stream used to load the SoundFont.
     pub fn new<R: Read>(reader: &mut R) -> Result<Self, SoundFontError> {
         let chunk_id = BinaryReader::read_four_cc(reader)?;
-        if &chunk_id != b"RIFF" {
+        if chunk_id != b"RIFF" {
             return Err(SoundFontError::RiffChunkNotFound);
         }
 
         let _size = BinaryReader::read_i32(reader);
 
         let form_type = BinaryReader::read_four_cc(reader)?;
-        if &form_type != b"sfbk" {
+        if form_type != b"sfbk" {
             return Err(SoundFontError::InvalidRiffChunkType {
                 expected: FourCC::from_bytes(*b"sfbk"),
                 actual: form_type,

--- a/rustysynth/src/soundfont_info.rs
+++ b/rustysynth/src/soundfont_info.rs
@@ -27,7 +27,7 @@ pub struct SoundFontInfo {
 impl SoundFontInfo {
     pub(crate) fn new<R: Read>(reader: &mut R) -> Result<Self, SoundFontError> {
         let chunk_id = BinaryReader::read_four_cc(reader)?;
-        if &chunk_id != b"LIST" {
+        if chunk_id != b"LIST" {
             return Err(SoundFontError::ListChunkNotFound);
         }
 
@@ -35,7 +35,7 @@ impl SoundFontInfo {
         let reader = &mut ReadCounter::new(reader);
 
         let list_type = BinaryReader::read_four_cc(reader)?;
-        if &list_type != b"INFO" {
+        if list_type != b"INFO" {
             return Err(SoundFontError::InvalidListChunkType {
                 expected: FourCC::from_bytes(*b"INFO"),
                 actual: list_type,

--- a/rustysynth/src/soundfont_info.rs
+++ b/rustysynth/src/soundfont_info.rs
@@ -31,7 +31,7 @@ impl SoundFontInfo {
             return Err(SoundFontError::ListChunkNotFound);
         }
 
-        let end = BinaryReader::read_i32(reader)? as usize;
+        let end = BinaryReader::read_u32(reader)? as usize;
         let reader = &mut ReadCounter::new(reader);
 
         let list_type = BinaryReader::read_four_cc(reader)?;
@@ -56,7 +56,7 @@ impl SoundFontInfo {
 
         while reader.bytes_read() < end {
             let id = BinaryReader::read_four_cc(reader)?;
-            let size = BinaryReader::read_i32(reader)? as usize;
+            let size = BinaryReader::read_u32(reader)? as usize;
 
             match id.as_bytes() {
                 b"ifil" => version = Some(SoundFontVersion::new(reader)?),

--- a/rustysynth/src/soundfont_parameters.rs
+++ b/rustysynth/src/soundfont_parameters.rs
@@ -29,7 +29,7 @@ impl SoundFontParameters {
             return Err(SoundFontError::ListChunkNotFound);
         }
 
-        let end = BinaryReader::read_i32(reader)? as usize;
+        let end = BinaryReader::read_u32(reader)? as usize;
         let reader = &mut ReadCounter::new(reader);
 
         let list_type = BinaryReader::read_four_cc(reader)?;
@@ -50,7 +50,7 @@ impl SoundFontParameters {
 
         while reader.bytes_read() < end {
             let id = BinaryReader::read_four_cc(reader)?;
-            let size = BinaryReader::read_i32(reader)? as usize;
+            let size = BinaryReader::read_u32(reader)? as usize;
 
             match id.as_bytes() {
                 b"phdr" => preset_infos = Some(PresetInfo::read_from_chunk(reader, size)?),

--- a/rustysynth/src/soundfont_parameters.rs
+++ b/rustysynth/src/soundfont_parameters.rs
@@ -25,7 +25,7 @@ pub(crate) struct SoundFontParameters {
 impl SoundFontParameters {
     pub(crate) fn new<R: Read>(reader: &mut R) -> Result<Self, SoundFontError> {
         let chunk_id = BinaryReader::read_four_cc(reader)?;
-        if &chunk_id != b"LIST" {
+        if chunk_id != b"LIST" {
             return Err(SoundFontError::ListChunkNotFound);
         }
 
@@ -33,7 +33,7 @@ impl SoundFontParameters {
         let reader = &mut ReadCounter::new(reader);
 
         let list_type = BinaryReader::read_four_cc(reader)?;
-        if &list_type != b"pdta" {
+        if list_type != b"pdta" {
             return Err(SoundFontError::InvalidListChunkType {
                 expected: FourCC::from_bytes(*b"pdta"),
                 actual: list_type,

--- a/rustysynth/src/soundfont_parameters.rs
+++ b/rustysynth/src/soundfont_parameters.rs
@@ -4,6 +4,7 @@ use std::io::Read;
 
 use crate::binary_reader::BinaryReader;
 use crate::error::SoundFontError;
+use crate::four_cc::FourCC;
 use crate::generator::Generator;
 use crate::instrument::Instrument;
 use crate::instrument_info::InstrumentInfo;
@@ -24,7 +25,7 @@ pub(crate) struct SoundFontParameters {
 impl SoundFontParameters {
     pub(crate) fn new<R: Read>(reader: &mut R) -> Result<Self, SoundFontError> {
         let chunk_id = BinaryReader::read_four_cc(reader)?;
-        if chunk_id != "LIST" {
+        if &chunk_id != b"LIST" {
             return Err(SoundFontError::ListChunkNotFound);
         }
 
@@ -32,9 +33,9 @@ impl SoundFontParameters {
         let reader = &mut ReadCounter::new(reader);
 
         let list_type = BinaryReader::read_four_cc(reader)?;
-        if list_type != "pdta" {
+        if &list_type != b"pdta" {
             return Err(SoundFontError::InvalidListChunkType {
-                expected: "pdta",
+                expected: FourCC::from_bytes(*b"pdta"),
                 actual: list_type,
             });
         }
@@ -51,63 +52,47 @@ impl SoundFontParameters {
             let id = BinaryReader::read_four_cc(reader)?;
             let size = BinaryReader::read_i32(reader)? as usize;
 
-            if id == "phdr" {
-                preset_infos = Some(PresetInfo::read_from_chunk(reader, size)?);
-            } else if id == "pbag" {
-                preset_bag = Some(ZoneInfo::read_from_chunk(reader, size)?);
-            } else if id == "pmod" {
-                BinaryReader::discard_data(reader, size)?;
-            } else if id == "pgen" {
-                preset_generators = Some(Generator::read_from_chunk(reader, size)?);
-            } else if id == "inst" {
-                instrument_infos = Some(InstrumentInfo::read_from_chunk(reader, size)?);
-            } else if id == "ibag" {
-                instrument_bag = Some(ZoneInfo::read_from_chunk(reader, size)?);
-            } else if id == "imod" {
-                BinaryReader::discard_data(reader, size)?;
-            } else if id == "igen" {
-                instrument_generators = Some(Generator::read_from_chunk(reader, size)?);
-            } else if id == "shdr" {
-                sample_headers = Some(SampleHeader::read_from_chunk(reader, size)?);
-            } else {
-                return Err(SoundFontError::ListContainsUnknownId(id));
+            match id.as_bytes() {
+                b"phdr" => preset_infos = Some(PresetInfo::read_from_chunk(reader, size)?),
+                b"pbag" => preset_bag = Some(ZoneInfo::read_from_chunk(reader, size)?),
+                b"pmod" => BinaryReader::discard_data(reader, size)?,
+                b"pgen" => preset_generators = Some(Generator::read_from_chunk(reader, size)?),
+                b"inst" => instrument_infos = Some(InstrumentInfo::read_from_chunk(reader, size)?),
+                b"ibag" => instrument_bag = Some(ZoneInfo::read_from_chunk(reader, size)?),
+                b"imod" => BinaryReader::discard_data(reader, size)?,
+                b"igen" => instrument_generators = Some(Generator::read_from_chunk(reader, size)?),
+                b"shdr" => sample_headers = Some(SampleHeader::read_from_chunk(reader, size)?),
+                _ => return Err(SoundFontError::ListContainsUnknownId(id)),
             }
         }
 
-        let preset_infos = match preset_infos {
-            Some(value) => value,
-            None => return Err(SoundFontError::SubChunkNotFound("PHDR")),
-        };
+        let preset_infos = preset_infos.ok_or(SoundFontError::SubChunkNotFound(
+            FourCC::from_bytes(*b"PHDR"),
+        ))?;
 
-        let preset_bag = match preset_bag {
-            Some(value) => value,
-            None => return Err(SoundFontError::SubChunkNotFound("PBAG")),
-        };
+        let preset_bag = preset_bag.ok_or(SoundFontError::SubChunkNotFound(FourCC::from_bytes(
+            *b"PBAG",
+        )))?;
 
-        let preset_generators = match preset_generators {
-            Some(value) => value,
-            None => return Err(SoundFontError::SubChunkNotFound("PGEN")),
-        };
+        let preset_generators = preset_generators.ok_or(SoundFontError::SubChunkNotFound(
+            FourCC::from_bytes(*b"PGEN"),
+        ))?;
 
-        let instrument_infos = match instrument_infos {
-            Some(value) => value,
-            None => return Err(SoundFontError::SubChunkNotFound("INST")),
-        };
+        let instrument_infos = instrument_infos.ok_or(SoundFontError::SubChunkNotFound(
+            FourCC::from_bytes(*b"INST"),
+        ))?;
 
-        let instrument_bag = match instrument_bag {
-            Some(value) => value,
-            None => return Err(SoundFontError::SubChunkNotFound("IBAG")),
-        };
+        let instrument_bag = instrument_bag.ok_or(SoundFontError::SubChunkNotFound(
+            FourCC::from_bytes(*b"IBAG"),
+        ))?;
 
-        let instrument_generators = match instrument_generators {
-            Some(value) => value,
-            None => return Err(SoundFontError::SubChunkNotFound("IGEN")),
-        };
+        let instrument_generators = instrument_generators.ok_or(
+            SoundFontError::SubChunkNotFound(FourCC::from_bytes(*b"IGEN")),
+        )?;
 
-        let sample_headers = match sample_headers {
-            Some(value) => value,
-            None => return Err(SoundFontError::SubChunkNotFound("SHDR")),
-        };
+        let sample_headers = sample_headers.ok_or(SoundFontError::SubChunkNotFound(
+            FourCC::from_bytes(*b"SHDR"),
+        ))?;
 
         let instrument_zones = Zone::create(&instrument_bag, &instrument_generators)?;
         let instruments =

--- a/rustysynth/src/soundfont_sampledata.rs
+++ b/rustysynth/src/soundfont_sampledata.rs
@@ -17,7 +17,7 @@ pub struct SoundFontSampleData {
 impl SoundFontSampleData {
     pub(crate) fn new<R: Read>(reader: &mut R) -> Result<Self, SoundFontError> {
         let chunk_id = BinaryReader::read_four_cc(reader)?;
-        if &chunk_id != b"LIST" {
+        if chunk_id != b"LIST" {
             return Err(SoundFontError::ListChunkNotFound);
         }
 
@@ -25,7 +25,7 @@ impl SoundFontSampleData {
         let reader = &mut ReadCounter::new(reader);
 
         let list_type = BinaryReader::read_four_cc(reader)?;
-        if &list_type != b"sdta" {
+        if list_type != b"sdta" {
             return Err(SoundFontError::InvalidListChunkType {
                 expected: FourCC::from_bytes(*b"sdta"),
                 actual: list_type,
@@ -38,12 +38,10 @@ impl SoundFontSampleData {
             let id = BinaryReader::read_four_cc(reader)?;
             let size = BinaryReader::read_u32(reader)? as usize;
 
-            if &id == b"smpl" {
-                wave_data = Some(BinaryReader::read_wave_data(reader, size)?);
-            } else if &id == b"sm24" {
-                BinaryReader::discard_data(reader, size)?;
-            } else {
-                return Err(SoundFontError::ListContainsUnknownId(id));
+            match id.as_bytes() {
+                b"smpl" => wave_data = Some(BinaryReader::read_wave_data(reader, size)?),
+                b"sm24" => BinaryReader::discard_data(reader, size)?,
+                _ => return Err(SoundFontError::ListContainsUnknownId(id)),
             }
         }
 
@@ -54,7 +52,7 @@ impl SoundFontSampleData {
 
         let ptr = wave_data.as_ptr() as *const u8;
         let four_cc = unsafe { slice::from_raw_parts(ptr, 4) };
-        if four_cc == "OggS".as_bytes() {
+        if four_cc == b"OggS" {
             return Err(SoundFontError::UnsupportedSampleFormat);
         }
 

--- a/rustysynth/src/soundfont_sampledata.rs
+++ b/rustysynth/src/soundfont_sampledata.rs
@@ -21,7 +21,7 @@ impl SoundFontSampleData {
             return Err(SoundFontError::ListChunkNotFound);
         }
 
-        let end = BinaryReader::read_i32(reader)? as usize;
+        let end = BinaryReader::read_u32(reader)? as usize;
         let reader = &mut ReadCounter::new(reader);
 
         let list_type = BinaryReader::read_four_cc(reader)?;
@@ -36,7 +36,7 @@ impl SoundFontSampleData {
 
         while reader.bytes_read() < end {
             let id = BinaryReader::read_four_cc(reader)?;
-            let size = BinaryReader::read_i32(reader)? as usize;
+            let size = BinaryReader::read_u32(reader)? as usize;
 
             if &id == b"smpl" {
                 wave_data = Some(BinaryReader::read_wave_data(reader, size)?);

--- a/rustysynth/src/soundfont_sampledata.rs
+++ b/rustysynth/src/soundfont_sampledata.rs
@@ -5,6 +5,7 @@ use std::slice;
 
 use crate::binary_reader::BinaryReader;
 use crate::error::SoundFontError;
+use crate::four_cc::FourCC;
 use crate::read_counter::ReadCounter;
 
 #[non_exhaustive]
@@ -16,7 +17,7 @@ pub struct SoundFontSampleData {
 impl SoundFontSampleData {
     pub(crate) fn new<R: Read>(reader: &mut R) -> Result<Self, SoundFontError> {
         let chunk_id = BinaryReader::read_four_cc(reader)?;
-        if chunk_id != "LIST" {
+        if &chunk_id != b"LIST" {
             return Err(SoundFontError::ListChunkNotFound);
         }
 
@@ -24,9 +25,9 @@ impl SoundFontSampleData {
         let reader = &mut ReadCounter::new(reader);
 
         let list_type = BinaryReader::read_four_cc(reader)?;
-        if list_type != "sdta" {
+        if &list_type != b"sdta" {
             return Err(SoundFontError::InvalidListChunkType {
-                expected: "sdta",
+                expected: FourCC::from_bytes(*b"sdta"),
                 actual: list_type,
             });
         }
@@ -37,9 +38,9 @@ impl SoundFontSampleData {
             let id = BinaryReader::read_four_cc(reader)?;
             let size = BinaryReader::read_i32(reader)? as usize;
 
-            if id == "smpl" {
+            if &id == b"smpl" {
                 wave_data = Some(BinaryReader::read_wave_data(reader, size)?);
-            } else if id == "sm24" {
+            } else if &id == b"sm24" {
                 BinaryReader::discard_data(reader, size)?;
             } else {
                 return Err(SoundFontError::ListContainsUnknownId(id));


### PR DESCRIPTION
The current code fails to parse SoundFonts greater than 2GB, because of code like the following:

https://github.com/sinshu/rustysynth/blob/b87a7f2329c049eb22f6345fb8e6a88b8528f5f1/rustysynth/src/soundfont_sampledata.rs#L23

When the size of the chunk is greater than 2GB, which makes the MSB be set, the resulting `usize` contains a value like `0xFFFFFFFF...`, due to the sign extension.

This PR adds `BinaryReader::read_u32` to prevent this. This PR also adds the type `FourCC` so `BinaryReader::read_four_cc` does not allocate a `String` redundantly.

Please refer to the following for more details in the numeric cast in Rust:

* The Reference:  https://doc.rust-lang.org/reference/expressions/operator-expr.html#numeric-cast
* Demo: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&code=fn+main%28%29+%7B%0A++++let+i%3A+i32+%3D+-1%3B%0A++++println%21%28%22%7B%3AX%7D%22%2C+i+as+usize%29%3B%0A%7D%0A