### PR TITLE
Allow changing midi file mid-playback

### DIFF
--- a/rustysynth/src/midifile.rs
+++ b/rustysynth/src/midifile.rs
@@ -132,7 +132,7 @@ impl Message {
 #[non_exhaustive]
 pub struct MidiFile {
     pub(crate) messages: Vec<Message>,
-    pub(crate) times: Vec<f64>,
+    pub times: Vec<f64>,
 }
 
 impl MidiFile {
@@ -143,6 +143,11 @@ impl MidiFile {
     /// * `reader` - The data stream used to load the MIDI file.
     pub fn new<R: Read>(reader: &mut R) -> Result<Self, MidiFileError> {
         MidiFile::new_with_loop_type(reader, MidiFileLoopType::LoopPoint(0))
+    }
+
+    pub fn update_file<R: Read>(&mut self, reader: &mut R) -> Result<(), MidiFileError> {
+        *self = MidiFile::new(reader)?;
+        Ok(())
     }
 
     /// Loads a MIDI file from the stream with a specified loop type.


### PR DESCRIPTION
I hacked this together because I needed it for this project: https://yeahross.itch.io/intern-music

Added this functionality so users can add/move/remove notes while the music is playing.

Not suggesting this should be merged in (it's a breaking change that breaks the example programs), but posting this here in case anyone else would be looking to extend the library in a similar way.