### PR TITLE
fix: Relax sized constraint for mutable readers

### DIFF
--- a/rustysynth/src/binary_reader.rs
+++ b/rustysynth/src/binary_reader.rs
@@ -13,55 +13,57 @@ use crate::four_cc::FourCC;
 pub(crate) struct BinaryReader {}
 
 impl BinaryReader {
-    pub(crate) fn read_i8<R: Read>(reader: &mut R) -> Result<i8, io::Error> {
+    pub(crate) fn read_i8<R: Read + ?Sized>(reader: &mut R) -> Result<i8, io::Error> {
         let mut data: [u8; 1] = [0; 1];
         reader.read_exact(&mut data)?;
         Ok(i8::from_le_bytes(data))
     }
 
-    pub(crate) fn read_u8<R: Read>(reader: &mut R) -> Result<u8, io::Error> {
+    pub(crate) fn read_u8<R: Read + ?Sized>(reader: &mut R) -> Result<u8, io::Error> {
         let mut data: [u8; 1] = [0; 1];
         reader.read_exact(&mut data)?;
         Ok(u8::from_le_bytes(data))
     }
 
-    pub(crate) fn read_i16<R: Read>(reader: &mut R) -> Result<i16, io::Error> {
+    pub(crate) fn read_i16<R: Read + ?Sized>(reader: &mut R) -> Result<i16, io::Error> {
         let mut data: [u8; 2] = [0; 2];
         reader.read_exact(&mut data)?;
         Ok(i16::from_le_bytes(data))
     }
 
-    pub(crate) fn read_u16<R: Read>(reader: &mut R) -> Result<u16, io::Error> {
+    pub(crate) fn read_u16<R: Read + ?Sized>(reader: &mut R) -> Result<u16, io::Error> {
         let mut data: [u8; 2] = [0; 2];
         reader.read_exact(&mut data)?;
         Ok(u16::from_le_bytes(data))
     }
 
-    pub(crate) fn read_i32<R: Read>(reader: &mut R) -> Result<i32, io::Error> {
+    pub(crate) fn read_i32<R: Read + ?Sized>(reader: &mut R) -> Result<i32, io::Error> {
         let mut data: [u8; 4] = [0; 4];
         reader.read_exact(&mut data)?;
         Ok(i32::from_le_bytes(data))
     }
 
-    pub(crate) fn read_u32<R: Read>(reader: &mut R) -> Result<u32, io::Error> {
+    pub(crate) fn read_u32<R: Read + ?Sized>(reader: &mut R) -> Result<u32, io::Error> {
         let mut data: [u8; 4] = [0; 4];
         reader.read_exact(&mut data)?;
         Ok(u32::from_le_bytes(data))
     }
 
-    pub(crate) fn read_i16_big_endian<R: Read>(reader: &mut R) -> Result<i16, io::Error> {
+    pub(crate) fn read_i16_big_endian<R: Read + ?Sized>(reader: &mut R) -> Result<i16, io::Error> {
         let mut data: [u8; 2] = [0; 2];
         reader.read_exact(&mut data)?;
         Ok(i16::from_be_bytes(data))
     }
 
-    pub(crate) fn read_i32_big_endian<R: Read>(reader: &mut R) -> Result<i32, io::Error> {
+    pub(crate) fn read_i32_big_endian<R: Read + ?Sized>(reader: &mut R) -> Result<i32, io::Error> {
         let mut data: [u8; 4] = [0; 4];
         reader.read_exact(&mut data)?;
         Ok(i32::from_be_bytes(data))
     }
 
-    pub(crate) fn read_i32_variable_length<R: Read>(reader: &mut R) -> Result<i32, io::Error> {
+    pub(crate) fn read_i32_variable_length<R: Read + ?Sized>(
+        reader: &mut R,
+    ) -> Result<i32, io::Error> {
         let mut acc: i32 = 0;
         let mut count: i32 = 0;
 
@@ -83,13 +85,13 @@ impl BinaryReader {
         Ok(acc)
     }
 
-    pub(crate) fn read_four_cc<R: Read>(reader: &mut R) -> Result<FourCC, io::Error> {
+    pub(crate) fn read_four_cc<R: Read + ?Sized>(reader: &mut R) -> Result<FourCC, io::Error> {
         let mut data: [u8; 4] = [0; 4];
         reader.read_exact(&mut data)?;
         Ok(FourCC::from_bytes(data))
     }
 
-    pub(crate) fn read_fixed_length_string<R: Read>(
+    pub(crate) fn read_fixed_length_string<R: Read + ?Sized>(
         reader: &mut R,
         length: usize,
     ) -> Result<String, io::Error> {
@@ -115,12 +117,15 @@ impl BinaryReader {
         Ok(str::from_utf8(&data[0..actual_length]).unwrap().to_string())
     }
 
-    pub(crate) fn discard_data<R: Read>(reader: &mut R, size: usize) -> Result<(), io::Error> {
+    pub(crate) fn discard_data<R: Read + ?Sized>(
+        reader: &mut R,
+        size: usize,
+    ) -> Result<(), io::Error> {
         let mut data: Vec<u8> = vec![0; size];
         reader.read_exact(&mut data)
     }
 
-    pub(crate) fn read_wave_data<R: Read>(
+    pub(crate) fn read_wave_data<R: Read + ?Sized>(
         reader: &mut R,
         size: usize,
     ) -> Result<Vec<i16>, io::Error> {

--- a/rustysynth/src/generator.rs
+++ b/rustysynth/src/generator.rs
@@ -12,7 +12,7 @@ pub(crate) struct Generator {
 }
 
 impl Generator {
-    fn new<R: Read>(reader: &mut R) -> Result<Self, SoundFontError> {
+    fn new<R: Read + ?Sized>(reader: &mut R) -> Result<Self, SoundFontError> {
         let generator_type = BinaryReader::read_u16(reader)?;
         let value = BinaryReader::read_u16(reader)?;
 
@@ -22,7 +22,7 @@ impl Generator {
         })
     }
 
-    pub(crate) fn read_from_chunk<R: Read>(
+    pub(crate) fn read_from_chunk<R: Read + ?Sized>(
         reader: &mut R,
         size: usize,
     ) -> Result<Vec<Generator>, SoundFontError> {

--- a/rustysynth/src/instrument_info.rs
+++ b/rustysynth/src/instrument_info.rs
@@ -13,7 +13,7 @@ pub(crate) struct InstrumentInfo {
 }
 
 impl InstrumentInfo {
-    fn new<R: Read>(reader: &mut R) -> Result<Self, SoundFontError> {
+    fn new<R: Read + ?Sized>(reader: &mut R) -> Result<Self, SoundFontError> {
         let name = BinaryReader::read_fixed_length_string(reader, 20)?;
         let zone_start_index = BinaryReader::read_u16(reader)? as i32;
 
@@ -24,7 +24,7 @@ impl InstrumentInfo {
         })
     }
 
-    pub(crate) fn read_from_chunk<R: Read>(
+    pub(crate) fn read_from_chunk<R: Read + ?Sized>(
         reader: &mut R,
         size: usize,
     ) -> Result<Vec<InstrumentInfo>, SoundFontError> {

--- a/rustysynth/src/midifile.rs
+++ b/rustysynth/src/midifile.rs
@@ -141,7 +141,7 @@ impl MidiFile {
     /// # Arguments
     ///
     /// * `reader` - The data stream used to load the MIDI file.
-    pub fn new<R: Read>(reader: &mut R) -> Result<Self, MidiFileError> {
+    pub fn new<R: Read + ?Sized>(reader: &mut R) -> Result<Self, MidiFileError> {
         MidiFile::new_with_loop_type(reader, MidiFileLoopType::LoopPoint(0))
     }
 
@@ -162,7 +162,7 @@ impl MidiFile {
     ///   CC #110 and #111 will be the start and end points of the loop.
     /// * `FinalFantasy` - The Final Fantasy style loop.
     ///   CC #116 and #117 will be the start and end points of the loop.
-    pub fn new_with_loop_type<R: Read>(
+    pub fn new_with_loop_type<R: Read + ?Sized>(
         reader: &mut R,
         loop_type: MidiFileLoopType,
     ) -> Result<Self, MidiFileError> {
@@ -225,13 +225,13 @@ impl MidiFile {
         Ok(Self { messages, times })
     }
 
-    fn discard_data<R: Read>(reader: &mut R) -> Result<(), MidiFileError> {
+    fn discard_data<R: Read + ?Sized>(reader: &mut R) -> Result<(), MidiFileError> {
         let size = BinaryReader::read_i32_variable_length(reader)? as usize;
         BinaryReader::discard_data(reader, size)?;
         Ok(())
     }
 
-    fn read_tempo<R: Read>(reader: &mut R) -> Result<i32, MidiFileError> {
+    fn read_tempo<R: Read + ?Sized>(reader: &mut R) -> Result<i32, MidiFileError> {
         let size = BinaryReader::read_i32_variable_length(reader)?;
         if size != 3 {
             return Err(MidiFileError::InvalidTempoValue);
@@ -244,7 +244,7 @@ impl MidiFile {
         Ok((b1 << 16) | (b2 << 8) | b3)
     }
 
-    fn read_track<R: Read>(
+    fn read_track<R: Read + ?Sized>(
         reader: &mut R,
         loop_type: MidiFileLoopType,
     ) -> Result<(Vec<Message>, Vec<i32>), MidiFileError> {

--- a/rustysynth/src/preset_info.rs
+++ b/rustysynth/src/preset_info.rs
@@ -18,7 +18,7 @@ pub(crate) struct PresetInfo {
 }
 
 impl PresetInfo {
-    fn new<R: Read>(reader: &mut R) -> Result<Self, SoundFontError> {
+    fn new<R: Read + ?Sized>(reader: &mut R) -> Result<Self, SoundFontError> {
         let name = BinaryReader::read_fixed_length_string(reader, 20)?;
         let patch_number = BinaryReader::read_u16(reader)? as i32;
         let bank_number = BinaryReader::read_u16(reader)? as i32;
@@ -39,7 +39,7 @@ impl PresetInfo {
         })
     }
 
-    pub(crate) fn read_from_chunk<R: Read>(
+    pub(crate) fn read_from_chunk<R: Read + ?Sized>(
         reader: &mut R,
         size: usize,
     ) -> Result<Vec<PresetInfo>, SoundFontError> {

--- a/rustysynth/src/read_counter.rs
+++ b/rustysynth/src/read_counter.rs
@@ -1,11 +1,11 @@
 use std::io::Read;
 
-pub(crate) struct ReadCounter<'a, R: Read> {
+pub(crate) struct ReadCounter<'a, R: Read + ?Sized> {
     reader: &'a mut R,
     count: usize,
 }
 
-impl<'a, R: Read> ReadCounter<'a, R> {
+impl<'a, R: Read + ?Sized> ReadCounter<'a, R> {
     pub(crate) fn new(reader: &'a mut R) -> Self {
         Self { reader, count: 0 }
     }
@@ -15,7 +15,7 @@ impl<'a, R: Read> ReadCounter<'a, R> {
     }
 }
 
-impl<R: Read> Read for ReadCounter<'_, R> {
+impl<R: Read + ?Sized> Read for ReadCounter<'_, R> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         let len = self.reader.read(buf)?;
         self.count += len;

--- a/rustysynth/src/sample_header.rs
+++ b/rustysynth/src/sample_header.rs
@@ -21,7 +21,7 @@ pub struct SampleHeader {
 }
 
 impl SampleHeader {
-    fn new<R: Read>(reader: &mut R) -> Result<Self, SoundFontError> {
+    fn new<R: Read + ?Sized>(reader: &mut R) -> Result<Self, SoundFontError> {
         let name = BinaryReader::read_fixed_length_string(reader, 20)?;
         let start = BinaryReader::read_i32(reader)?;
         let end = BinaryReader::read_i32(reader)?;
@@ -47,7 +47,7 @@ impl SampleHeader {
         })
     }
 
-    pub(crate) fn read_from_chunk<R: Read>(
+    pub(crate) fn read_from_chunk<R: Read + ?Sized>(
         reader: &mut R,
         size: usize,
     ) -> Result<Vec<SampleHeader>, SoundFontError> {

--- a/rustysynth/src/soundfont.rs
+++ b/rustysynth/src/soundfont.rs
@@ -30,7 +30,7 @@ impl SoundFont {
     /// # Arguments
     ///
     /// * `reader` - The data stream used to load the SoundFont.
-    pub fn new<R: Read>(reader: &mut R) -> Result<Self, SoundFontError> {
+    pub fn new<R: Read + ?Sized>(reader: &mut R) -> Result<Self, SoundFontError> {
         let chunk_id = BinaryReader::read_four_cc(reader)?;
         if chunk_id != b"RIFF" {
             return Err(SoundFontError::RiffChunkNotFound);

--- a/rustysynth/src/soundfont_info.rs
+++ b/rustysynth/src/soundfont_info.rs
@@ -25,7 +25,7 @@ pub struct SoundFontInfo {
 }
 
 impl SoundFontInfo {
-    pub(crate) fn new<R: Read>(reader: &mut R) -> Result<Self, SoundFontError> {
+    pub(crate) fn new<R: Read + ?Sized>(reader: &mut R) -> Result<Self, SoundFontError> {
         let chunk_id = BinaryReader::read_four_cc(reader)?;
         if chunk_id != b"LIST" {
             return Err(SoundFontError::ListChunkNotFound);

--- a/rustysynth/src/soundfont_parameters.rs
+++ b/rustysynth/src/soundfont_parameters.rs
@@ -23,7 +23,7 @@ pub(crate) struct SoundFontParameters {
 }
 
 impl SoundFontParameters {
-    pub(crate) fn new<R: Read>(reader: &mut R) -> Result<Self, SoundFontError> {
+    pub(crate) fn new<R: Read + ?Sized>(reader: &mut R) -> Result<Self, SoundFontError> {
         let chunk_id = BinaryReader::read_four_cc(reader)?;
         if chunk_id != b"LIST" {
             return Err(SoundFontError::ListChunkNotFound);

--- a/rustysynth/src/soundfont_sampledata.rs
+++ b/rustysynth/src/soundfont_sampledata.rs
@@ -15,7 +15,7 @@ pub struct SoundFontSampleData {
 }
 
 impl SoundFontSampleData {
-    pub(crate) fn new<R: Read>(reader: &mut R) -> Result<Self, SoundFontError> {
+    pub(crate) fn new<R: Read + ?Sized>(reader: &mut R) -> Result<Self, SoundFontError> {
         let chunk_id = BinaryReader::read_four_cc(reader)?;
         if chunk_id != b"LIST" {
             return Err(SoundFontError::ListChunkNotFound);

--- a/rustysynth/src/soundfont_version.rs
+++ b/rustysynth/src/soundfont_version.rs
@@ -17,7 +17,7 @@ impl SoundFontVersion {
         Self { major: 0, minor: 0 }
     }
 
-    pub(crate) fn new<R: Read>(reader: &mut R) -> Result<Self, io::Error> {
+    pub(crate) fn new<R: Read + ?Sized>(reader: &mut R) -> Result<Self, io::Error> {
         let major = BinaryReader::read_i16(reader)?;
         let minor = BinaryReader::read_i16(reader)?;
 

--- a/rustysynth/src/zone_info.rs
+++ b/rustysynth/src/zone_info.rs
@@ -12,7 +12,7 @@ pub(crate) struct ZoneInfo {
 }
 
 impl ZoneInfo {
-    fn new<R: Read>(reader: &mut R) -> Result<Self, SoundFontError> {
+    fn new<R: Read + ?Sized>(reader: &mut R) -> Result<Self, SoundFontError> {
         let generator_index = BinaryReader::read_u16(reader)? as i32;
         let modulator_index = BinaryReader::read_u16(reader)? as i32;
 
@@ -24,7 +24,7 @@ impl ZoneInfo {
         })
     }
 
-    pub(crate) fn read_from_chunk<R: Read>(
+    pub(crate) fn read_from_chunk<R: Read + ?Sized>(
         reader: &mut R,
         size: usize,
     ) -> Result<Vec<ZoneInfo>, SoundFontError> {


### PR DESCRIPTION
Hello! Much appreciated for porting your synthesizer to rust. 

## Objective
Since there are no types that need to "own" some reader `R`, it's good to accept an `&mut dyn Reader`. This is useful in cases such as `bevy`, where the [`Asset`](https://docs.rs/bevy_asset/latest/bevy_asset/trait.AssetLoader.html) management system only provides a `dyn Read` type.

## Solution
Relax the implicit `Sized` constraint for readers (add `?Sized` bound).

This change does not break interfaces.



### Side Note
Thanks for your awesome work. I've spent some time refactoring your repo in another crate, but the changes are too drastic for me to push here.

