### PR TITLE
Fix: Crash on loading a soundfont with empty preset header chunk

### DIFF
--- a/rustysynth/src/preset_info.rs
+++ b/rustysynth/src/preset_info.rs
@@ -43,7 +43,7 @@ impl PresetInfo {
         reader: &mut R,
         size: usize,
     ) -> Result<Vec<PresetInfo>, SoundFontError> {
-        if size % 38 != 0 {
+        if size == 0 || size % 38 != 0 {
             return Err(SoundFontError::InvalidPresetList);
         }
 


### PR DESCRIPTION
I found a way cause a panic with invalid data. It guess it's quite unlikely to encounter, but here's a fix.

The file to test it with: [test_output.zip](https://github.com/user-attachments/files/18307953/test_output.zip)
