### PR TITLE
Fix: crash on empty pgen chunk

### DIFF
--- a/rustysynth/src/generator.rs
+++ b/rustysynth/src/generator.rs
@@ -26,7 +26,7 @@ impl Generator {
         reader: &mut R,
         size: usize,
     ) -> Result<Vec<Generator>, SoundFontError> {
-        if size % 4 != 0 {
+        if size == 0 || size % 4 != 0 {
             return Err(SoundFontError::InvalidGeneratorList);
         }
 

--- a/rustysynth/src/sample_header.rs
+++ b/rustysynth/src/sample_header.rs
@@ -51,7 +51,7 @@ impl SampleHeader {
         reader: &mut R,
         size: usize,
     ) -> Result<Vec<SampleHeader>, SoundFontError> {
-        if size % 46 != 0 {
+        if size == 0 || size % 46 != 0 {
             return Err(SoundFontError::InvalidSampleHeaderList);
         }
 

--- a/rustysynth/src/zone_info.rs
+++ b/rustysynth/src/zone_info.rs
@@ -28,7 +28,7 @@ impl ZoneInfo {
         reader: &mut R,
         size: usize,
     ) -> Result<Vec<ZoneInfo>, SoundFontError> {
-        if size % 4 != 0 {
+        if size == 0 || size % 4 != 0 {
             return Err(SoundFontError::InvalidZoneList);
         }
 


### PR DESCRIPTION
Same as #31 

Sample file: [test_output_empty_pgen.zip](https://github.com/user-attachments/files/18310259/test_output_empty_pgen.zip)

There may be a few more fixes like this coming up; I'm sketching a tool that generates soundfonts and I use RustySynth to loosely validate its output.