### PR TITLE
Fix sanitycheck samplebounds

### DIFF
--- a/rustysynth/src/error.rs
+++ b/rustysynth/src/error.rs
@@ -76,15 +76,7 @@ pub enum SoundFontError {
     InvalidZoneList,
     ZoneNotFound,
     InvalidGeneratorList,
-    RegionCheckFailed {
-        inst_name: String,
-        region_idx: usize,
-        msg: String,
-    },
-    RegionSampleOutOfBounds {
-        inst_name: String,
-        region_idx: usize,
-    },
+    SanityCheckFailed,
 }
 
 impl error::Error for SoundFontError {
@@ -150,12 +142,7 @@ impl fmt::Display for SoundFontError {
             SoundFontError::InvalidZoneList => write!(f, "the zone list is invalid"),
             SoundFontError::ZoneNotFound => write!(f, "no valid zone was found"),
             SoundFontError::InvalidGeneratorList => write!(f, "the generator list is invalid"),
-            SoundFontError::RegionCheckFailed{ inst_name, region_idx, msg } => {
-                write!(f, "Error at inst {inst_name}, zone {region_idx}: {msg}")
-            }
-            SoundFontError::RegionSampleOutOfBounds { inst_name, region_idx } => {
-                write!(f, "Error at inst {inst_name}, zone {region_idx}: Sample out of bounds")
-            }
+            SoundFontError::SanityCheckFailed => write!(f, "sanity check failed"),
         }
     }
 }

--- a/rustysynth/src/error.rs
+++ b/rustysynth/src/error.rs
@@ -76,7 +76,15 @@ pub enum SoundFontError {
     InvalidZoneList,
     ZoneNotFound,
     InvalidGeneratorList,
-    SanityCheckFailed,
+    RegionCheckFailed {
+        inst_name: String,
+        region_idx: usize,
+        msg: String,
+    },
+    RegionSampleOutOfBounds {
+        inst_name: String,
+        region_idx: usize,
+    },
 }
 
 impl error::Error for SoundFontError {
@@ -142,7 +150,12 @@ impl fmt::Display for SoundFontError {
             SoundFontError::InvalidZoneList => write!(f, "the zone list is invalid"),
             SoundFontError::ZoneNotFound => write!(f, "no valid zone was found"),
             SoundFontError::InvalidGeneratorList => write!(f, "the generator list is invalid"),
-            SoundFontError::SanityCheckFailed => write!(f, "sanity check failed"),
+            SoundFontError::RegionCheckFailed{ inst_name, region_idx, msg } => {
+                write!(f, "Error at inst {inst_name}, zone {region_idx}: {msg}")
+            }
+            SoundFontError::RegionSampleOutOfBounds { inst_name, region_idx } => {
+                write!(f, "Error at inst {inst_name}, zone {region_idx}: Sample out of bounds")
+            }
         }
     }
 }

--- a/rustysynth/src/soundfont.rs
+++ b/rustysynth/src/soundfont.rs
@@ -77,13 +77,7 @@ impl SoundFont {
                 if end >= self.wave_data.len() {
                     return Err(SoundFontError::SanityCheckFailed);
                 }
-                if start_loop < start {
-                    return Err(SoundFontError::SanityCheckFailed);
-                }
-                if end_loop <= start_loop {
-                    return Err(SoundFontError::SanityCheckFailed);
-                }
-                if end < end_loop {
+                if start_loop < start || end_loop <= start_loop || end < end_loop {
                     return Err(SoundFontError::SanityCheckFailed);
                 }
             }

--- a/rustysynth/src/soundfont.rs
+++ b/rustysynth/src/soundfont.rs
@@ -90,7 +90,7 @@ impl SoundFont {
                     return Err(SoundFontError::RegionCheckFailed {
                         inst_name,
                         region_idx,
-                        msg: "end < start".into(),
+                        msg: "end <= start".into(),
                     });
                 }
                 if end_loop < start_loop {

--- a/rustysynth/src/soundfont.rs
+++ b/rustysynth/src/soundfont.rs
@@ -67,10 +67,8 @@ impl SoundFont {
     fn sanity_check(&self) -> Result<(), SoundFontError> {
         // https://github.com/sinshu/rustysynth/issues/22
         // https://github.com/sinshu/rustysynth/issues/33
-        for (inst_idx, instrument) in self.instruments.iter().enumerate() {
-            for (region_idx, region) in instrument.regions.iter().enumerate() {
-                let inst_name = format!("{inst_idx} {:?}", instrument.get_name());
-
+        for instrument in &self.instruments {
+            for region in &instrument.regions {
                 let start = region.get_sample_start();
                 let end = region.get_sample_end();
                 let start_loop = region.get_sample_start_loop();
@@ -80,25 +78,10 @@ impl SoundFont {
                     || start_loop < 0
                     || end as usize >= self.wave_data.len()
                     || end_loop as usize >= self.wave_data.len()
+                    || end <= start
+                    || end_loop < start_loop
                 {
-                    return Err(SoundFontError::RegionSampleOutOfBounds {
-                        inst_name,
-                        region_idx,
-                    });
-                }
-                if end <= start {
-                    return Err(SoundFontError::RegionCheckFailed {
-                        inst_name,
-                        region_idx,
-                        msg: "end <= start".into(),
-                    });
-                }
-                if end_loop < start_loop {
-                    return Err(SoundFontError::RegionCheckFailed {
-                        inst_name,
-                        region_idx,
-                        msg: "end_loop < start_loop".into(),
-                    });
+                    return Err(SoundFontError::SanityCheckFailed);
                 }
             }
         }

--- a/rustysynth/src/soundfont.rs
+++ b/rustysynth/src/soundfont.rs
@@ -66,9 +66,24 @@ impl SoundFont {
 
     fn sanity_check(&self) -> Result<(), SoundFontError> {
         // https://github.com/sinshu/rustysynth/issues/22
+        // https://github.com/sinshu/rustysynth/issues/33
         for instrument in self.instruments.iter() {
             for region in instrument.regions.iter() {
-                if region.get_sample_end_loop() < region.get_sample_start_loop() {
+                let start = region.get_sample_start() as usize;
+                let end = region.get_sample_end() as usize;
+                let start_loop = region.get_sample_start_loop() as usize;
+                let end_loop = region.get_sample_end_loop() as usize;
+
+                if end >= self.wave_data.len() {
+                    return Err(SoundFontError::SanityCheckFailed);
+                }
+                if start_loop < start {
+                    return Err(SoundFontError::SanityCheckFailed);
+                }
+                if end_loop <= start_loop {
+                    return Err(SoundFontError::SanityCheckFailed);
+                }
+                if end < end_loop {
                     return Err(SoundFontError::SanityCheckFailed);
                 }
             }

--- a/rustysynth/src/soundfont.rs
+++ b/rustysynth/src/soundfont.rs
@@ -67,18 +67,38 @@ impl SoundFont {
     fn sanity_check(&self) -> Result<(), SoundFontError> {
         // https://github.com/sinshu/rustysynth/issues/22
         // https://github.com/sinshu/rustysynth/issues/33
-        for instrument in self.instruments.iter() {
-            for region in instrument.regions.iter() {
-                let start = region.get_sample_start() as usize;
-                let end = region.get_sample_end() as usize;
-                let start_loop = region.get_sample_start_loop() as usize;
-                let end_loop = region.get_sample_end_loop() as usize;
+        for (inst_idx, instrument) in self.instruments.iter().enumerate() {
+            for (region_idx, region) in instrument.regions.iter().enumerate() {
+                let inst_name = format!("{inst_idx} {:?}", instrument.get_name());
 
-                if end >= self.wave_data.len() {
-                    return Err(SoundFontError::SanityCheckFailed);
+                let start = region.get_sample_start();
+                let end = region.get_sample_end();
+                let start_loop = region.get_sample_start_loop();
+                let end_loop = region.get_sample_end_loop();
+
+                if start < 0
+                    || start_loop < 0
+                    || end as usize >= self.wave_data.len()
+                    || end_loop as usize >= self.wave_data.len()
+                {
+                    return Err(SoundFontError::RegionSampleOutOfBounds {
+                        inst_name,
+                        region_idx,
+                    });
                 }
-                if start_loop < start || end_loop <= start_loop || end < end_loop {
-                    return Err(SoundFontError::SanityCheckFailed);
+                if end <= start {
+                    return Err(SoundFontError::RegionCheckFailed {
+                        inst_name,
+                        region_idx,
+                        msg: "end < start".into(),
+                    });
+                }
+                if end_loop < start_loop {
+                    return Err(SoundFontError::RegionCheckFailed {
+                        inst_name,
+                        region_idx,
+                        msg: "end_loop < start_loop".into(),
+                    });
                 }
             }
         }


### PR DESCRIPTION
Closes #33

This should fix any issues with sample ranges; I tried to craft a soundfont that causes a crash with these values, but I can't find a way to break it anymore.

Checking at sample level is _probably_ unnecessary, since they're only used at instrument level.

Draft PR. TODO:

- [x] ~~Account for `sampleModes` generator~~
- [x] Provide more info in the error type.
- [x] Test it with a bunch of real fonts