### PR TITLE
Fix: LoopMode enumeration

### DIFF
--- a/rustysynth/src/instrument_region.rs
+++ b/rustysynth/src/instrument_region.rs
@@ -361,12 +361,7 @@ impl InstrumentRegion {
     }
 
     pub fn get_sample_modes(&self) -> LoopMode {
-        let value = self.gs[GeneratorType::SAMPLE_MODES as usize];
-        let mode = LoopMode::from(value);
-        if let LoopMode::Invalid(_) = mode {
-            return LoopMode::NoLoop;
-        }
-        mode
+        LoopMode::from(self.gs[GeneratorType::SAMPLE_MODES as usize])
     }
 
     pub fn get_scale_tuning(&self) -> i32 {

--- a/rustysynth/src/instrument_region.rs
+++ b/rustysynth/src/instrument_region.rs
@@ -363,10 +363,10 @@ impl InstrumentRegion {
     pub fn get_sample_modes(&self) -> LoopMode {
         let value = self.gs[GeneratorType::SAMPLE_MODES as usize];
         let mode = LoopMode::from(value);
-        match mode {
-            LoopMode::Invalid(_) => LoopMode::NoLoop,
-            _ => mode,
+        if let LoopMode::Invalid(_) = mode {
+            return LoopMode::NoLoop;
         }
+        mode
     }
 
     pub fn get_scale_tuning(&self) -> i32 {

--- a/rustysynth/src/instrument_region.rs
+++ b/rustysynth/src/instrument_region.rs
@@ -360,12 +360,13 @@ impl InstrumentRegion {
         self.gs[GeneratorType::FINE_TUNE as usize] as i32 + self.sample_pitch_correction
     }
 
-    pub fn get_sample_modes(&self) -> i32 {
-        if self.gs[GeneratorType::SAMPLE_MODES as usize] != 2 {
-            self.gs[GeneratorType::SAMPLE_MODES as usize] as i32
-        } else {
-            LoopMode::NO_LOOP
-        }
+    pub fn get_sample_modes(&self) -> LoopMode {
+        let value = self.gs[GeneratorType::SAMPLE_MODES as usize];
+        let mode = LoopMode::from(value);
+        return match mode {
+            LoopMode::Invalid(_) => LoopMode::NoLoop,
+            _ => mode,
+        };
     }
 
     pub fn get_scale_tuning(&self) -> i32 {

--- a/rustysynth/src/instrument_region.rs
+++ b/rustysynth/src/instrument_region.rs
@@ -363,10 +363,10 @@ impl InstrumentRegion {
     pub fn get_sample_modes(&self) -> LoopMode {
         let value = self.gs[GeneratorType::SAMPLE_MODES as usize];
         let mode = LoopMode::from(value);
-        return match mode {
+        match mode {
             LoopMode::Invalid(_) => LoopMode::NoLoop,
             _ => mode,
-        };
+        }
     }
 
     pub fn get_scale_tuning(&self) -> i32 {

--- a/rustysynth/src/lib.rs
+++ b/rustysynth/src/lib.rs
@@ -50,6 +50,7 @@ pub use self::error::SoundFontError;
 pub use self::error::SynthesizerError;
 pub use self::instrument::Instrument;
 pub use self::instrument_region::InstrumentRegion;
+pub use self::loop_mode::LoopMode;
 pub use self::midifile::MidiFile;
 pub use self::midifile_looptype::MidiFileLoopType;
 pub use self::midifile_sequencer::MidiFileSequencer;

--- a/rustysynth/src/loop_mode.rs
+++ b/rustysynth/src/loop_mode.rs
@@ -1,12 +1,29 @@
-#![allow(dead_code)]
+#[derive(Debug, PartialEq, Eq)]
+pub enum LoopMode {
+    NoLoop,
+    Continuous,
+    LoopUntilNoteOff,
+    Invalid(i16),
+}
 
-#[allow(unused)]
-#[non_exhaustive]
-pub(crate) struct LoopMode {}
+impl From<i16> for LoopMode {
+    fn from(value: i16) -> Self {
+        match value {
+            0 => LoopMode::NoLoop,
+            1 => LoopMode::Continuous,
+            3 => LoopMode::LoopUntilNoteOff,
+            _ => LoopMode::Invalid(value),
+        }
+    }
+}
 
-#[allow(unused)]
-impl LoopMode {
-    pub(crate) const NO_LOOP: i32 = 0;
-    pub(crate) const CONTINUOUS: i32 = 0;
-    pub(crate) const LOOP_UNTIL_NOTE_OFF: i32 = 0;
+impl From<LoopMode> for i16 {
+    fn from(mode: LoopMode) -> Self {
+        match mode {
+            LoopMode::NoLoop => 0,
+            LoopMode::Continuous => 1,
+            LoopMode::LoopUntilNoteOff => 3,
+            LoopMode::Invalid(value) => value,
+        }
+    }
 }

--- a/rustysynth/src/loop_mode.rs
+++ b/rustysynth/src/loop_mode.rs
@@ -1,29 +1,37 @@
+/// Specifies how the synthesizer loops the sample.
+/// Corresponds to sampleModes enumerator in SoundFont 2 spec.
+///
+/// RustySynth doesn't support nonstandard loop modes.
+/// Undefined values will fall back to `LoopMode::NoLoop`.
+/// ```
+/// use rustysynth::LoopMode;
+///
+/// assert_eq!(LoopMode::NoLoop as i16, 0);
+/// assert_eq!(LoopMode::Continuous as u8, 1);
+/// assert_eq!(LoopMode::LoopUntilNoteOff as u64 as f32, 3.0);
+///
+/// assert_eq!(LoopMode::from(0), LoopMode::NoLoop);
+/// assert_eq!(LoopMode::from(1), LoopMode::Continuous);
+/// assert_eq!(LoopMode::from(2), LoopMode::NoLoop);
+/// assert_eq!(LoopMode::from(3), LoopMode::LoopUntilNoteOff);
+/// assert_eq!(LoopMode::from(50), LoopMode::NoLoop);
+/// ```
 #[derive(Debug, PartialEq, Eq)]
 pub enum LoopMode {
-    NoLoop,
-    Continuous,
-    LoopUntilNoteOff,
-    Invalid(i16),
+    /// The sample will not loop.
+    NoLoop = 0,
+    /// The sample will loop continuously.
+    Continuous = 1,
+    /// The sample will loop and play the remainder once the note is released.
+    LoopUntilNoteOff = 3,
 }
 
 impl From<i16> for LoopMode {
     fn from(value: i16) -> Self {
         match value {
-            0 => LoopMode::NoLoop,
             1 => LoopMode::Continuous,
             3 => LoopMode::LoopUntilNoteOff,
-            _ => LoopMode::Invalid(value),
-        }
-    }
-}
-
-impl From<LoopMode> for i16 {
-    fn from(mode: LoopMode) -> Self {
-        match mode {
-            LoopMode::NoLoop => 0,
-            LoopMode::Continuous => 1,
-            LoopMode::LoopUntilNoteOff => 3,
-            LoopMode::Invalid(value) => value,
+            _ => LoopMode::NoLoop,
         }
     }
 }

--- a/rustysynth/src/oscillator.rs
+++ b/rustysynth/src/oscillator.rs
@@ -12,7 +12,7 @@ use crate::synthesizer_settings::SynthesizerSettings;
 pub(crate) struct Oscillator {
     synthesizer_sample_rate: i32,
 
-    loop_mode: i32,
+    loop_mode: LoopMode,
     sample_sample_rate: i32,
     start: i32,
     end: i32,
@@ -37,7 +37,7 @@ impl Oscillator {
     pub(crate) fn new(settings: &SynthesizerSettings) -> Self {
         Self {
             synthesizer_sample_rate: settings.sample_rate,
-            loop_mode: 0,
+            loop_mode: LoopMode::NoLoop,
             sample_sample_rate: 0,
             start: 0,
             end: 0,
@@ -55,7 +55,7 @@ impl Oscillator {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn start(
         &mut self,
-        loop_mode: i32,
+        loop_mode: LoopMode,
         sample_rate: i32,
         start: i32,
         end: i32,
@@ -77,12 +77,12 @@ impl Oscillator {
         self.tune = coarse_tune as f32 + 0.01_f32 * fine_tune as f32;
         self.pitch_change_scale = 0.01_f32 * scale_tuning as f32;
         self.sample_rate_ratio = sample_rate as f32 / self.synthesizer_sample_rate as f32;
-        self.looping = self.loop_mode != LoopMode::NO_LOOP;
+        self.looping = self.loop_mode != LoopMode::NoLoop;
         self.position_fp = (start as i64) << Oscillator::FRAC_BITS;
     }
 
     pub(crate) fn release(&mut self) {
-        if self.loop_mode == LoopMode::LOOP_UNTIL_NOTE_OFF {
+        if self.loop_mode == LoopMode::LoopUntilNoteOff {
             self.looping = false;
         }
     }

--- a/rustysynth/src/region_pair.rs
+++ b/rustysynth/src/region_pair.rs
@@ -2,6 +2,7 @@
 
 use crate::generator_type::GeneratorType;
 use crate::instrument_region::InstrumentRegion;
+use crate::loop_mode::LoopMode;
 use crate::preset_region::PresetRegion;
 use crate::soundfont_math::SoundFontMath;
 
@@ -216,7 +217,7 @@ impl<'a> RegionPair<'a> {
         self.gs(GeneratorType::FINE_TUNE as usize) + self.instrument.sample_pitch_correction
     }
 
-    pub(crate) fn get_sample_modes(&self) -> i32 {
+    pub(crate) fn get_sample_modes(&self) -> LoopMode {
         self.instrument.get_sample_modes()
     }
 

--- a/rustysynth_test/src/instrument_util.rs
+++ b/rustysynth_test/src/instrument_util.rs
@@ -63,7 +63,7 @@ pub fn check(region: &InstrumentRegion, values: &[f64; 50]) {
     assert!(are_equal(region.get_initial_attenuation() as f64, values[43]));
     assert!(are_equal(region.get_coarse_tune() as f64, values[44]));
     assert!(are_equal(region.get_fine_tune() as f64, values[45]));
-    assert!(are_equal(i16::from(region.get_sample_modes()) as f64, values[46]));
+    assert!(are_equal(region.get_sample_modes() as usize as f64, values[46]));
     assert!(are_equal(region.get_scale_tuning() as f64, values[47]));
     assert!(are_equal(region.get_exclusive_class() as f64, values[48]));
     assert!(are_equal(region.get_root_key() as f64, values[49]));

--- a/rustysynth_test/src/instrument_util.rs
+++ b/rustysynth_test/src/instrument_util.rs
@@ -63,7 +63,7 @@ pub fn check(region: &InstrumentRegion, values: &[f64; 50]) {
     assert!(are_equal(region.get_initial_attenuation() as f64, values[43]));
     assert!(are_equal(region.get_coarse_tune() as f64, values[44]));
     assert!(are_equal(region.get_fine_tune() as f64, values[45]));
-    assert!(are_equal(region.get_sample_modes() as f64, values[46]));
+    assert!(are_equal(i16::from(region.get_sample_modes()) as f64, values[46]));
     assert!(are_equal(region.get_scale_tuning() as f64, values[47]));
     assert!(are_equal(region.get_exclusive_class() as f64, values[48]));
     assert!(are_equal(region.get_root_key() as f64, values[49]));


### PR DESCRIPTION
Closes #35 

A very quick refactor and fix for LoopMode. It doesn't break playback, but I haven't yet tested how it affects loop behavior.

The style of this new code is closer to how Rust generally looks like, but also sticks out as very different to the rest. The enum itself should be good, but I don't know if using it all the way up `get_sample_modes()` was actually a good idea.