### PR TITLE
refactor: use unsigned where reasonable

### DIFF
--- a/rustysynth/src/channel.rs
+++ b/rustysynth/src/channel.rs
@@ -12,22 +12,22 @@ enum DataType {
 pub(crate) struct Channel {
     pub(crate) is_percussion_channel: bool,
 
-    bank_number: i32,
-    patch_number: i32,
+    bank_number: u8,
+    patch_number: u8,
 
-    modulation: i16,
-    volume: i16,
-    pan: i16,
-    expression: i16,
+    modulation: u16,
+    volume: u16,
+    pan: u16,
+    expression: u16,
     hold_pedal: bool,
 
     reverb_send: u8,
     chorus_send: u8,
 
-    rpn: i16,
-    pitch_bend_range: i16,
+    rpn: u16,
+    pitch_bend_range: u16,
     coarse_tune: i16,
-    fine_tune: i16,
+    fine_tune: u16,
 
     pitch_bend: f32,
 
@@ -73,7 +73,7 @@ impl Channel {
         self.reverb_send = 40;
         self.chorus_send = 0;
 
-        self.rpn = -1;
+        self.rpn = 0xFFFF;
         self.pitch_bend_range = 2 << 7;
         self.coarse_tune = 0;
         self.fine_tune = 8192;
@@ -86,12 +86,12 @@ impl Channel {
         self.expression = 127 << 7;
         self.hold_pedal = false;
 
-        self.rpn = -1;
+        self.rpn = 0xFFFF;
 
         self.pitch_bend = 0_f32;
     }
 
-    pub(crate) fn set_bank(&mut self, value: i32) {
+    pub(crate) fn set_bank(&mut self, value: u8) {
         self.bank_number = value;
 
         if self.is_percussion_channel {
@@ -99,107 +99,108 @@ impl Channel {
         }
     }
 
-    pub(crate) fn set_patch(&mut self, value: i32) {
+    pub(crate) fn set_patch(&mut self, value: u8) {
         self.patch_number = value;
     }
 
-    pub(crate) fn set_modulation_coarse(&mut self, value: i32) {
-        self.modulation = (self.modulation & 0x7F) | (value << 7) as i16;
+    pub(crate) fn set_modulation_coarse(&mut self, value: u8) {
+        self.modulation = (self.modulation & 0x7F) | ((value as u16) << 7);
     }
 
-    pub(crate) fn set_modulation_fine(&mut self, value: i32) {
-        self.modulation = (((self.modulation as i32) & 0xFF80) | value) as i16;
+    pub(crate) fn set_modulation_fine(&mut self, value: u8) {
+        self.modulation = (self.modulation & 0xFF80) | value as u16;
     }
 
-    pub(crate) fn set_volume_coarse(&mut self, value: i32) {
-        self.volume = (self.volume & 0x7F) | (value << 7) as i16;
+    pub(crate) fn set_volume_coarse(&mut self, value: u8) {
+        self.volume = (self.volume & 0x7F) | ((value as u16) << 7);
     }
 
-    pub(crate) fn set_volume_fine(&mut self, value: i32) {
-        self.volume = (((self.volume as i32) & 0xFF80) | value) as i16;
+    pub(crate) fn set_volume_fine(&mut self, value: u8) {
+        self.volume = (self.volume & 0xFF80) | value as u16;
     }
 
-    pub(crate) fn set_pan_coarse(&mut self, value: i32) {
-        self.pan = (self.pan & 0x7F) | (value << 7) as i16;
+    pub(crate) fn set_pan_coarse(&mut self, value: u8) {
+        self.pan = (self.pan & 0x7F) | ((value as u16) << 7);
     }
 
-    pub(crate) fn set_pan_fine(&mut self, value: i32) {
-        self.pan = (((self.pan as i32) & 0xFF80) | value) as i16;
+    pub(crate) fn set_pan_fine(&mut self, value: u8) {
+        self.pan = (self.pan & 0xFF80) | value as u16;
     }
 
-    pub(crate) fn set_expression_coarse(&mut self, value: i32) {
-        self.expression = (self.expression & 0x7F) | (value << 7) as i16;
+    pub(crate) fn set_expression_coarse(&mut self, value: u8) {
+        self.expression = (self.expression & 0x7F) | ((value as u16) << 7);
     }
 
-    pub(crate) fn set_expression_fine(&mut self, value: i32) {
-        self.expression = (((self.expression as i32) & 0xFF80) | value) as i16;
+    pub(crate) fn set_expression_fine(&mut self, value: u8) {
+        self.expression = ((self.expression) & 0xFF80) | value as u16;
     }
 
-    pub(crate) fn set_hold_pedal(&mut self, value: i32) {
+    pub(crate) fn set_hold_pedal(&mut self, value: u8) {
         self.hold_pedal = value >= 64;
     }
 
-    pub(crate) fn set_reverb_send(&mut self, value: i32) {
-        self.reverb_send = value as u8;
+    pub(crate) fn set_reverb_send(&mut self, value: u8) {
+        self.reverb_send = value;
     }
 
-    pub(crate) fn set_chorus_send(&mut self, value: i32) {
-        self.chorus_send = value as u8;
+    pub(crate) fn set_chorus_send(&mut self, value: u8) {
+        self.chorus_send = value;
     }
 
-    pub(crate) fn set_rpn_coarse(&mut self, value: i32) {
-        self.rpn = (self.rpn & 0x7F) | (value << 7) as i16;
+    pub(crate) fn set_rpn_coarse(&mut self, value: u8) {
+        self.rpn = (self.rpn & 0x7F) | ((value as u16) << 7);
         self.last_data_type = DataType::Rpn;
     }
 
-    pub(crate) fn set_rpn_fine(&mut self, value: i32) {
-        self.rpn = (((self.rpn as i32) & 0xFF80) | value) as i16;
+    pub(crate) fn set_rpn_fine(&mut self, value: u8) {
+        self.rpn = (self.rpn & 0xFF80) | value as u16;
         self.last_data_type = DataType::Rpn;
     }
 
-    pub(crate) fn set_nrpn_coarse(&mut self, _value: i32) {
+    pub(crate) fn set_nrpn_coarse(&mut self, _value: u8) {
         self.last_data_type = DataType::Nrpn;
     }
 
-    pub(crate) fn set_nrpn_fine(&mut self, _value: i32) {
+    pub(crate) fn set_nrpn_fine(&mut self, _value: u8) {
         self.last_data_type = DataType::Nrpn;
     }
 
-    pub(crate) fn data_entry_coarse(&mut self, value: i32) {
+    pub(crate) fn data_entry_coarse(&mut self, value: u8) {
         if self.last_data_type != DataType::Rpn {
             return;
         }
 
         if self.rpn == 0 {
-            self.pitch_bend_range = (self.pitch_bend_range & 0x7F) | (value << 7) as i16;
+            self.pitch_bend_range = (self.pitch_bend_range & 0x7F) | ((value as u16) << 7);
         } else if self.rpn == 1 {
-            self.fine_tune = (self.fine_tune & 0x7F) | (value << 7) as i16;
+            self.fine_tune = (self.fine_tune & 0x7F) | (value << 7) as u16;
         } else if self.rpn == 2 {
             self.coarse_tune = (value - 64) as i16;
         }
     }
 
-    pub(crate) fn data_entry_fine(&mut self, value: i32) {
+    pub(crate) fn data_entry_fine(&mut self, value: u8) {
         if self.last_data_type != DataType::Rpn {
             return;
         }
 
         if self.rpn == 0 {
-            self.pitch_bend_range = (((self.pitch_bend_range as i32) & 0xFF80) | value) as i16;
+            self.pitch_bend_range = (self.pitch_bend_range & 0xFF80) | value as u16;
         } else if self.rpn == 1 {
-            self.fine_tune = (((self.fine_tune as i32) & 0xFF80) | value) as i16;
+            self.fine_tune = (self.fine_tune & 0xFF80) | value as u16;
         }
     }
 
-    pub(crate) fn set_pitch_bend(&mut self, value1: i32, value2: i32) {
-        self.pitch_bend = (1_f32 / 8192_f32) * ((value1 | (value2 << 7)) - 8192) as f32;
+    pub(crate) fn set_pitch_bend(&mut self, value1: u8, value2: u8) {
+        self.pitch_bend =
+            (1_f32 / 8192_f32) * (((value1 as i32) | ((value2 as i32) << 7)) - 8192) as f32;
     }
 
-    pub(crate) fn get_bank_number(&self) -> i32 {
+    pub(crate) fn get_bank_number(&self) -> u8 {
         self.bank_number
     }
 
-    pub(crate) fn get_patch_number(&self) -> i32 {
+    pub(crate) fn get_patch_number(&self) -> u8 {
         self.patch_number
     }
 

--- a/rustysynth/src/channel.rs
+++ b/rustysynth/src/channel.rs
@@ -173,7 +173,7 @@ impl Channel {
         if self.rpn == 0 {
             self.pitch_bend_range = (self.pitch_bend_range & 0x7F) | ((value as u16) << 7);
         } else if self.rpn == 1 {
-            self.fine_tune = (self.fine_tune & 0x7F) | (value << 7) as u16;
+            self.fine_tune = (self.fine_tune & 0x7F) | ((value as u16) << 7);
         } else if self.rpn == 2 {
             self.coarse_tune = (value - 64) as i16;
         }

--- a/rustysynth/src/instrument_region.rs
+++ b/rustysynth/src/instrument_region.rs
@@ -138,7 +138,7 @@ impl InstrumentRegion {
     ///
     /// * `key` - The key of a note.
     /// * `velocity` - The velocity of a note.
-    pub fn contains(&self, key: i32, velocity: i32) -> bool {
+    pub fn contains(&self, key: u8, velocity: u8) -> bool {
         let contains_key = self.get_key_range_start() <= key && key <= self.get_key_range_end();
         let contains_velocity = self.get_velocity_range_start() <= velocity
             && velocity <= self.get_velocity_range_end();
@@ -333,20 +333,20 @@ impl InstrumentRegion {
         self.gs[GeneratorType::KEY_NUMBER_TO_VOLUME_ENVELOPE_DECAY as usize] as i32
     }
 
-    pub fn get_key_range_start(&self) -> i32 {
-        self.gs[GeneratorType::KEY_RANGE as usize] as i32 & 0xFF
+    pub fn get_key_range_start(&self) -> u8 {
+        (self.gs[GeneratorType::KEY_RANGE as usize] & 0xFF) as u8
     }
 
-    pub fn get_key_range_end(&self) -> i32 {
-        (self.gs[GeneratorType::KEY_RANGE as usize] as i32 >> 8) & 0xFF
+    pub fn get_key_range_end(&self) -> u8 {
+        ((self.gs[GeneratorType::KEY_RANGE as usize] >> 8) & 0xFF) as u8
     }
 
-    pub fn get_velocity_range_start(&self) -> i32 {
-        self.gs[GeneratorType::VELOCITY_RANGE as usize] as i32 & 0xFF
+    pub fn get_velocity_range_start(&self) -> u8 {
+        (self.gs[GeneratorType::VELOCITY_RANGE as usize] & 0xFF) as u8
     }
 
-    pub fn get_velocity_range_end(&self) -> i32 {
-        (self.gs[GeneratorType::VELOCITY_RANGE as usize] as i32 >> 8) & 0xFF
+    pub fn get_velocity_range_end(&self) -> u8 {
+        ((self.gs[GeneratorType::VELOCITY_RANGE as usize] >> 8) & 0xFF) as u8
     }
 
     pub fn get_initial_attenuation(&self) -> f32 {

--- a/rustysynth/src/midifile_sequencer.rs
+++ b/rustysynth/src/midifile_sequencer.rs
@@ -120,9 +120,12 @@ impl MidiFileSequencer {
 
             if time <= self.current_time {
                 if msg.get_message_type() == Message::NORMAL {
-                    let status = msg.channel | msg.command;
-                    self.synthesizer
-                        .process_midi_message(status, msg.data1, msg.data2);
+                    self.synthesizer.process_midi_message(
+                        msg.channel,
+                        msg.command,
+                        msg.data1,
+                        msg.data2,
+                    );
                 } else if self.play_loop {
                     if msg.get_message_type() == Message::LOOP_START {
                         self.loop_index = self.msg_index;

--- a/rustysynth/src/midifile_sequencer.rs
+++ b/rustysynth/src/midifile_sequencer.rs
@@ -120,12 +120,9 @@ impl MidiFileSequencer {
 
             if time <= self.current_time {
                 if msg.get_message_type() == Message::NORMAL {
-                    self.synthesizer.process_midi_message(
-                        msg.channel as i32,
-                        msg.command as i32,
-                        msg.data1 as i32,
-                        msg.data2 as i32,
-                    );
+                    let status = msg.channel | msg.command;
+                    self.synthesizer
+                        .process_midi_message(status, msg.data1, msg.data2);
                 } else if self.play_loop {
                     if msg.get_message_type() == Message::LOOP_START {
                         self.loop_index = self.msg_index;

--- a/rustysynth/src/preset_region.rs
+++ b/rustysynth/src/preset_region.rs
@@ -107,7 +107,7 @@ impl PresetRegion {
     ///
     /// * `key` - The key of a note.
     /// * `velocity` - The velocity of a note.
-    pub fn contains(&self, key: i32, velocity: i32) -> bool {
+    pub fn contains(&self, key: u8, velocity: u8) -> bool {
         let contains_key = self.get_key_range_start() <= key && key <= self.get_key_range_end();
         let contains_velocity = self.get_velocity_range_start() <= velocity
             && velocity <= self.get_velocity_range_end();
@@ -268,20 +268,20 @@ impl PresetRegion {
         self.gs[GeneratorType::KEY_NUMBER_TO_VOLUME_ENVELOPE_DECAY as usize] as i32
     }
 
-    pub fn get_key_range_start(&self) -> i32 {
-        self.gs[GeneratorType::KEY_RANGE as usize] as i32 & 0xFF
+    pub fn get_key_range_start(&self) -> u8 {
+        (self.gs[GeneratorType::KEY_RANGE as usize] & 0xFF) as u8
     }
 
-    pub fn get_key_range_end(&self) -> i32 {
-        (self.gs[GeneratorType::KEY_RANGE as usize] as i32 >> 8) & 0xFF
+    pub fn get_key_range_end(&self) -> u8 {
+        ((self.gs[GeneratorType::KEY_RANGE as usize] >> 8) & 0xFF) as u8
     }
 
-    pub fn get_velocity_range_start(&self) -> i32 {
-        self.gs[GeneratorType::VELOCITY_RANGE as usize] as i32 & 0xFF
+    pub fn get_velocity_range_start(&self) -> u8 {
+        (self.gs[GeneratorType::VELOCITY_RANGE as usize] & 0xFF) as u8
     }
 
-    pub fn get_velocity_range_end(&self) -> i32 {
-        (self.gs[GeneratorType::VELOCITY_RANGE as usize] as i32 >> 8) & 0xFF
+    pub fn get_velocity_range_end(&self) -> u8 {
+        ((self.gs[GeneratorType::VELOCITY_RANGE as usize] >> 8) & 0xFF) as u8
     }
 
     pub fn get_initial_attenuation(&self) -> f32 {

--- a/rustysynth/src/region_ex.rs
+++ b/rustysynth/src/region_ex.rs
@@ -41,8 +41,8 @@ impl RegionEx {
     pub(crate) fn start_volume_envelope(
         envelope: &mut VolumeEnvelope,
         region: &RegionPair,
-        key: i32,
-        _velocity: i32,
+        key: u8,
+        _velocity: u8,
     ) {
         // If the release time is shorter than 10 ms, it will be clamped to 10 ms to avoid pop noise.
 
@@ -67,8 +67,8 @@ impl RegionEx {
     pub(crate) fn start_modulation_envelope(
         envelope: &mut ModulationEnvelope,
         region: &RegionPair,
-        key: i32,
-        velocity: i32,
+        key: u8,
+        velocity: u8,
     ) {
         // According to the implementation of TinySoundFont, the attack time should be adjusted by the velocity.
 
@@ -90,14 +90,14 @@ impl RegionEx {
         envelope.start(delay, attack, hold, decay, sustain, release);
     }
 
-    pub(crate) fn start_vibrato(lfo: &mut Lfo, region: &RegionPair, _key: i32, _velocity: i32) {
+    pub(crate) fn start_vibrato(lfo: &mut Lfo, region: &RegionPair, _key: u8, _velocity: u8) {
         lfo.start(
             region.get_delay_vibrato_lfo(),
             region.get_frequency_vibrato_lfo(),
         );
     }
 
-    pub(crate) fn start_modulation(lfo: &mut Lfo, region: &RegionPair, _key: i32, _velocity: i32) {
+    pub(crate) fn start_modulation(lfo: &mut Lfo, region: &RegionPair, _key: u8, _velocity: u8) {
         lfo.start(
             region.get_delay_modulation_lfo(),
             region.get_frequency_modulation_lfo(),

--- a/rustysynth/src/soundfont_math.rs
+++ b/rustysynth/src/soundfont_math.rs
@@ -49,8 +49,8 @@ impl SoundFontMath {
         20_f32 * x.log10()
     }
 
-    pub(crate) fn key_number_to_multiplying_factor(cents: i32, key: i32) -> f32 {
-        SoundFontMath::timecents_to_seconds((cents * (60 - key)) as f32)
+    pub(crate) fn key_number_to_multiplying_factor(cents: i32, key: u8) -> f32 {
+        SoundFontMath::timecents_to_seconds((cents * (60 - key as i32)) as f32)
     }
 
     pub(crate) fn exp_cutoff(x: f64) -> f64 {

--- a/rustysynth/src/synthesizer.rs
+++ b/rustysynth/src/synthesizer.rs
@@ -131,7 +131,7 @@ impl Synthesizer {
     /// * `data1`  - The first data part of the message.
     /// * `data2`  - The second data part of the message.
     pub fn process_midi_message(&mut self, channel: u8, command: u8, data1: u8, data2: u8) {
-        if (channel as i32) >= (self.channels.len() as i32) {
+        if channel as usize >= self.channels.len() {
             return;
         }
 
@@ -178,7 +178,7 @@ impl Synthesizer {
     /// * `channel` - The channel of the note.
     /// * `key` - The key of the note.
     pub fn note_off(&mut self, channel: u8, key: u8) {
-        if (channel as i32) >= self.channels.len() as i32 {
+        if channel as usize >= self.channels.len() {
             return;
         }
 
@@ -202,7 +202,7 @@ impl Synthesizer {
             return;
         }
 
-        if (channel as i32) >= self.channels.len() as i32 {
+        if channel as usize >= self.channels.len() {
             return;
         }
 
@@ -298,7 +298,7 @@ impl Synthesizer {
     ///
     /// * `channel` - The channel to be reset.
     pub fn reset_all_controllers_channel(&mut self, channel: u8) {
-        if (channel as i32) >= self.channels.len() as i32 {
+        if channel as usize >= self.channels.len() {
             return;
         }
 

--- a/rustysynth/src/synthesizer.rs
+++ b/rustysynth/src/synthesizer.rs
@@ -130,9 +130,7 @@ impl Synthesizer {
     /// * `status` - the MIDI status byte (contains a channel and command)
     /// * `data1`  - The first data part of the message.
     /// * `data2`  - The second data part of the message.
-    pub fn process_midi_message(&mut self, status: u8, data1: u8, data2: u8) {
-        let channel = status & 0x0F;
-        let command = status & 0xF0;
+    pub fn process_midi_message(&mut self, channel: u8, command: u8, data1: u8, data2: u8) {
         if (channel as i32) >= (self.channels.len() as i32) {
             return;
         }

--- a/rustysynth/src/voice.rs
+++ b/rustysynth/src/voice.rs
@@ -45,9 +45,9 @@ pub(crate) struct Voice {
     pub(crate) current_chorus_send: f32,
 
     pub(crate) exclusive_class: i32,
-    pub(crate) channel: i32,
-    pub(crate) key: i32,
-    pub(crate) velocity: i32,
+    pub(crate) channel: u8,
+    pub(crate) key: u8,
+    pub(crate) velocity: u8,
 
     note_gain: f32,
 
@@ -123,7 +123,7 @@ impl Voice {
         }
     }
 
-    pub(crate) fn start(&mut self, region: &RegionPair, channel: i32, key: i32, velocity: i32) {
+    pub(crate) fn start(&mut self, region: &RegionPair, channel: u8, key: u8, velocity: u8) {
         self.exclusive_class = region.get_exclusive_class();
         self.channel = channel;
         self.key = key;

--- a/rustysynth/src/voice_collection.rs
+++ b/rustysynth/src/voice_collection.rs
@@ -28,7 +28,7 @@ impl VoiceCollection {
     pub(crate) fn request_new(
         &mut self,
         region: &InstrumentRegion,
-        channel: i32,
+        channel: u8,
     ) -> Option<&mut Voice> {
         // If an exclusive class is assigned to the region, find a voice with the same class.
         // If found, reuse it to avoid playing multiple voices with the same class at a time.

--- a/rustysynth_test/src/soundfont3_test.rs
+++ b/rustysynth_test/src/soundfont3_test.rs
@@ -12,11 +12,8 @@ fn soundfont3_load_test() {
     path.push("MuseScore_General.sf3");
     let mut file = File::open(&path).unwrap();
     let result = SoundFont::new(&mut file);
-    match result {
-        Ok(_) => panic!(),
-        Err(err) => match err {
-            SoundFontError::UnsupportedSampleFormat => {}
-            _ => panic!(),
-        },
-    }
+    assert!(matches!(
+        result,
+        Err(SoundFontError::UnsupportedSampleFormat)
+    ));
 }

--- a/rustysynth_test/src/soundfont3_test.rs
+++ b/rustysynth_test/src/soundfont3_test.rs
@@ -13,10 +13,10 @@ fn soundfont3_load_test() {
     let mut file = File::open(&path).unwrap();
     let result = SoundFont::new(&mut file);
     match result {
-        Ok(_) => assert!(false),
+        Ok(_) => panic!(),
         Err(err) => match err {
-            SoundFontError::UnsupportedSampleFormat => return,
-            _ => assert!(false),
+            SoundFontError::UnsupportedSampleFormat => {}
+            _ => panic!(),
         },
     }
 }


### PR DESCRIPTION
I think this helps resolve #2 .

There is a breaking change, which is that the `channel` and `command` bytes for process_midi_message are enjoined.
I understand if you do not want that. However, this synth is quite reliable and I'd like to align the parameters as close as possible to the format of a Voice Event...but nbd!

Separately, I cannot run the tests, so I'd like to see what I broke hahaah