### PR TITLE
Refactor: EnvelopeState integer to enum

### DIFF
--- a/rustysynth/src/envelope_stage.rs
+++ b/rustysynth/src/envelope_stage.rs
@@ -1,14 +1,20 @@
-#![allow(dead_code)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum EnvelopeStage {
+    Delay = 0,
+    Attack = 1,
+    Hold = 2,
+    Decay = 3,
+    Release = 4,
+}
 
-#[allow(unused)]
-#[non_exhaustive]
-pub(crate) struct EnvelopeStage {}
-
-#[allow(unused)]
 impl EnvelopeStage {
-    pub(crate) const DELAY: i32 = 0;
-    pub(crate) const ATTACK: i32 = 1;
-    pub(crate) const HOLD: i32 = 2;
-    pub(crate) const DECAY: i32 = 3;
-    pub(crate) const RELEASE: i32 = 4;
+    pub const fn next_stage(&self) -> Option<Self> {
+        match self {
+            Self::Delay => Some(Self::Attack),
+            Self::Attack => Some(Self::Hold),
+            Self::Hold => Some(Self::Decay),
+            Self::Decay => Some(Self::Release),
+            Self::Release => None,
+        }
+    }
 }


### PR DESCRIPTION
I went to look at files that are not touched by #39 and found `EnvelopeStage`.

**Changes:**
- Convert the type into an enum
- Replace envelope stage if-else chains with match statements

This should make the code easier to read, and also make it impossible to assign an invalid value to the fields.

**Tests:**
I made these fonts and used them to listen if the envelopes still work:
[mod_test_fonts.zip](https://github.com/user-attachments/files/19720988/mod_test_fonts.zip)
