### PR TITLE
voice.rs cleanup

### DIFF
--- a/rustysynth/src/synthesizer.rs
+++ b/rustysynth/src/synthesizer.rs
@@ -184,7 +184,7 @@ impl Synthesizer {
         }
 
         for voice in self.voices.get_active_voices().iter_mut() {
-            if voice.channel == channel && voice.key == key {
+            if voice.get_channel() == channel && voice.get_key() == key {
                 voice.end();
             }
         }
@@ -272,13 +272,13 @@ impl Synthesizer {
     pub fn note_off_all_channel(&mut self, channel: i32, immediate: bool) {
         if immediate {
             for voice in self.voices.get_active_voices().iter_mut() {
-                if voice.channel == channel {
+                if voice.get_channel() == channel {
                     voice.kill();
                 }
             }
         } else {
             for voice in self.voices.get_active_voices().iter_mut() {
-                if voice.channel == channel {
+                if voice.get_channel() == channel {
                     voice.end();
                 }
             }
@@ -371,7 +371,7 @@ impl Synthesizer {
             Synthesizer::write_block(
                 previous_gain_left,
                 current_gain_left,
-                &voice.block[..],
+                voice.get_block(),
                 &mut self.block_left[..],
                 self.inverse_block_size,
             );
@@ -380,7 +380,7 @@ impl Synthesizer {
             Synthesizer::write_block(
                 previous_gain_right,
                 current_gain_right,
-                &voice.block[..],
+                voice.get_block(),
                 &mut self.block_right[..],
                 self.inverse_block_size,
             );
@@ -400,7 +400,7 @@ impl Synthesizer {
                 Synthesizer::write_block(
                     previous_gain_left,
                     current_gain_left,
-                    &voice.block[..],
+                    voice.get_block(),
                     chorus_input_left,
                     self.inverse_block_size,
                 );
@@ -410,7 +410,7 @@ impl Synthesizer {
                 Synthesizer::write_block(
                     previous_gain_right,
                     current_gain_right,
-                    &voice.block[..],
+                    voice.get_block(),
                     chorus_input_right,
                     self.inverse_block_size,
                 );
@@ -447,7 +447,7 @@ impl Synthesizer {
                 Synthesizer::write_block(
                     previous_gain,
                     current_gain,
-                    &voice.block[..],
+                    voice.get_block(),
                     &mut reverb_input[..],
                     self.inverse_block_size,
                 );

--- a/rustysynth/src/synthesizer.rs
+++ b/rustysynth/src/synthesizer.rs
@@ -184,7 +184,7 @@ impl Synthesizer {
         }
 
         for voice in self.voices.get_active_voices().iter_mut() {
-            if voice.get_channel() == channel && voice.get_key() == key {
+            if voice.channel() == channel && voice.key() == key {
                 voice.end();
             }
         }
@@ -272,13 +272,13 @@ impl Synthesizer {
     pub fn note_off_all_channel(&mut self, channel: i32, immediate: bool) {
         if immediate {
             for voice in self.voices.get_active_voices().iter_mut() {
-                if voice.get_channel() == channel {
+                if voice.channel() == channel {
                     voice.kill();
                 }
             }
         } else {
             for voice in self.voices.get_active_voices().iter_mut() {
-                if voice.get_channel() == channel {
+                if voice.channel() == channel {
                     voice.end();
                 }
             }
@@ -371,7 +371,7 @@ impl Synthesizer {
             Synthesizer::write_block(
                 previous_gain_left,
                 current_gain_left,
-                voice.get_block(),
+                voice.block(),
                 &mut self.block_left[..],
                 self.inverse_block_size,
             );
@@ -380,7 +380,7 @@ impl Synthesizer {
             Synthesizer::write_block(
                 previous_gain_right,
                 current_gain_right,
-                voice.get_block(),
+                voice.block(),
                 &mut self.block_right[..],
                 self.inverse_block_size,
             );
@@ -400,7 +400,7 @@ impl Synthesizer {
                 Synthesizer::write_block(
                     previous_gain_left,
                     current_gain_left,
-                    voice.get_block(),
+                    voice.block(),
                     chorus_input_left,
                     self.inverse_block_size,
                 );
@@ -410,7 +410,7 @@ impl Synthesizer {
                 Synthesizer::write_block(
                     previous_gain_right,
                     current_gain_right,
-                    voice.get_block(),
+                    voice.block(),
                     chorus_input_right,
                     self.inverse_block_size,
                 );
@@ -447,7 +447,7 @@ impl Synthesizer {
                 Synthesizer::write_block(
                     previous_gain,
                     current_gain,
-                    voice.get_block(),
+                    voice.block(),
                     &mut reverb_input[..],
                     self.inverse_block_size,
                 );

--- a/rustysynth/src/voice.rs
+++ b/rustysynth/src/voice.rs
@@ -25,7 +25,6 @@ enum VoiceState {
 #[non_exhaustive]
 pub(crate) struct Voice {
     sample_rate: i32,
-    block_size: usize,
 
     vol_env: VolumeEnvelope,
     mod_env: ModulationEnvelope,
@@ -90,7 +89,6 @@ impl Voice {
     pub(crate) fn new(settings: &SynthesizerSettings) -> Self {
         Self {
             sample_rate: settings.sample_rate,
-            block_size: settings.block_size,
             vol_env: VolumeEnvelope::new(settings),
             mod_env: ModulationEnvelope::new(settings),
             vib_lfo: Lfo::new(settings),
@@ -201,11 +199,11 @@ impl Voice {
 
         self.release_if_necessary(channel_info);
 
-        if !self.vol_env.process(self.block_size) {
+        if !self.vol_env.process(self.block.len()) {
             return false;
         }
 
-        self.mod_env.process(self.block_size);
+        self.mod_env.process(self.block.len());
         self.vib_lfo.process();
         self.mod_lfo.process();
 
@@ -281,7 +279,7 @@ impl Voice {
             self.previous_chorus_send = self.current_chorus_send;
         }
 
-        self.voice_length += self.block_size;
+        self.voice_length += self.block.len();
 
         true
     }

--- a/rustysynth/src/voice.rs
+++ b/rustysynth/src/voice.rs
@@ -24,8 +24,6 @@ enum VoiceState {
 #[derive(Debug)]
 #[non_exhaustive]
 pub(crate) struct Voice {
-    sample_rate: i32,
-
     vol_env: VolumeEnvelope,
     mod_env: ModulationEnvelope,
 
@@ -88,7 +86,6 @@ pub(crate) struct Voice {
 impl Voice {
     pub(crate) fn new(settings: &SynthesizerSettings) -> Self {
         Self {
-            sample_rate: settings.sample_rate,
             vol_env: VolumeEnvelope::new(settings),
             mod_env: ModulationEnvelope::new(settings),
             vib_lfo: Lfo::new(settings),

--- a/rustysynth/src/voice.rs
+++ b/rustysynth/src/voice.rs
@@ -33,7 +33,7 @@ pub(crate) struct Voice {
     oscillator: Oscillator,
     filter: BiQuadFilter,
 
-    pub(crate) block: Vec<f32>,
+    block: Vec<f32>,
 
     // A sudden change in the mix gain will cause pop noise.
     // To avoid this, we save the mix gain of the previous block,
@@ -49,10 +49,10 @@ pub(crate) struct Voice {
     pub(crate) current_reverb_send: f32,
     pub(crate) current_chorus_send: f32,
 
-    pub(crate) exclusive_class: i32,
-    pub(crate) channel: i32,
-    pub(crate) key: i32,
-    pub(crate) velocity: i32,
+    exclusive_class: i32,
+    channel: i32,
+    key: i32,
+    velocity: i32,
 
     note_gain: f32,
 
@@ -79,7 +79,7 @@ pub(crate) struct Voice {
     smoothed_cutoff: f32,
 
     voice_state: VoiceState,
-    pub(crate) voice_length: usize,
+    samples_elapsed: usize,
     min_voice_length: usize,
 }
 
@@ -121,7 +121,7 @@ impl Voice {
             instrument_chorus: 0_f32,
             smoothed_cutoff: 0_f32,
             voice_state: VoiceState::Playing,
-            voice_length: 0,
+            samples_elapsed: 0,
             min_voice_length: (settings.sample_rate / 500) as usize,
         }
     }
@@ -174,7 +174,7 @@ impl Voice {
         self.smoothed_cutoff = self.cutoff;
 
         self.voice_state = VoiceState::Playing;
-        self.voice_length = 0;
+        self.samples_elapsed = 0;
     }
 
     pub(crate) fn end(&mut self) {
@@ -269,20 +269,20 @@ impl Voice {
             1_f32,
         );
 
-        if self.voice_length == 0 {
+        if self.samples_elapsed == 0 {
             self.previous_mix_gain_left = self.current_mix_gain_left;
             self.previous_mix_gain_right = self.current_mix_gain_right;
             self.previous_reverb_send = self.current_reverb_send;
             self.previous_chorus_send = self.current_chorus_send;
         }
 
-        self.voice_length += self.block.len();
+        self.samples_elapsed += self.block.len();
 
         true
     }
 
     fn release_if_necessary(&mut self, channel_info: &Channel) {
-        if self.voice_length < self.min_voice_length {
+        if self.samples_elapsed < self.min_voice_length {
             return;
         }
 
@@ -293,6 +293,26 @@ impl Voice {
 
             self.voice_state = VoiceState::Released;
         }
+    }
+
+    pub(crate) fn get_block(&self) -> &Vec<f32> {
+        &self.block
+    }
+
+    pub(crate) fn get_samples_elapsed(&self) -> usize {
+        self.samples_elapsed
+    }
+
+    pub(crate) fn get_exclusive_class(&self) -> i32 {
+        self.exclusive_class
+    }
+
+    pub(crate) fn get_channel(&self) -> i32 {
+        self.channel
+    }
+
+    pub(crate) fn get_key(&self) -> i32 {
+        self.key
     }
 
     pub(crate) fn get_priority(&self) -> f32 {

--- a/rustysynth/src/voice.rs
+++ b/rustysynth/src/voice.rs
@@ -296,27 +296,27 @@ impl Voice {
         }
     }
 
-    pub(crate) fn get_block(&self) -> &Vec<f32> {
+    pub(crate) fn block(&self) -> &Vec<f32> {
         &self.block
     }
 
-    pub(crate) fn get_voice_length(&self) -> usize {
+    pub(crate) fn voice_length(&self) -> usize {
         self.voice_length
     }
 
-    pub(crate) fn get_exclusive_class(&self) -> i32 {
+    pub(crate) fn exclusive_class(&self) -> i32 {
         self.exclusive_class
     }
 
-    pub(crate) fn get_channel(&self) -> i32 {
+    pub(crate) fn channel(&self) -> i32 {
         self.channel
     }
 
-    pub(crate) fn get_key(&self) -> i32 {
+    pub(crate) fn key(&self) -> i32 {
         self.key
     }
 
-    pub(crate) fn get_priority(&self) -> f32 {
+    pub(crate) fn priority(&self) -> f32 {
         if self.note_gain < SoundFontMath::NON_AUDIBLE {
             0_f32
         } else {

--- a/rustysynth/src/voice.rs
+++ b/rustysynth/src/voice.rs
@@ -79,7 +79,8 @@ pub(crate) struct Voice {
     smoothed_cutoff: f32,
 
     voice_state: VoiceState,
-    samples_elapsed: usize,
+    /// Time elapsed in samples
+    voice_length: usize,
     min_voice_length: usize,
 }
 
@@ -121,7 +122,7 @@ impl Voice {
             instrument_chorus: 0_f32,
             smoothed_cutoff: 0_f32,
             voice_state: VoiceState::Playing,
-            samples_elapsed: 0,
+            voice_length: 0,
             min_voice_length: (settings.sample_rate / 500) as usize,
         }
     }
@@ -174,7 +175,7 @@ impl Voice {
         self.smoothed_cutoff = self.cutoff;
 
         self.voice_state = VoiceState::Playing;
-        self.samples_elapsed = 0;
+        self.voice_length = 0;
     }
 
     pub(crate) fn end(&mut self) {
@@ -269,20 +270,20 @@ impl Voice {
             1_f32,
         );
 
-        if self.samples_elapsed == 0 {
+        if self.voice_length == 0 {
             self.previous_mix_gain_left = self.current_mix_gain_left;
             self.previous_mix_gain_right = self.current_mix_gain_right;
             self.previous_reverb_send = self.current_reverb_send;
             self.previous_chorus_send = self.current_chorus_send;
         }
 
-        self.samples_elapsed += self.block.len();
+        self.voice_length += self.block.len();
 
         true
     }
 
     fn release_if_necessary(&mut self, channel_info: &Channel) {
-        if self.samples_elapsed < self.min_voice_length {
+        if self.voice_length < self.min_voice_length {
             return;
         }
 
@@ -299,8 +300,8 @@ impl Voice {
         &self.block
     }
 
-    pub(crate) fn get_samples_elapsed(&self) -> usize {
-        self.samples_elapsed
+    pub(crate) fn get_voice_length(&self) -> usize {
+        self.voice_length
     }
 
     pub(crate) fn get_exclusive_class(&self) -> i32 {

--- a/rustysynth/src/voice_collection.rs
+++ b/rustysynth/src/voice_collection.rs
@@ -36,7 +36,8 @@ impl VoiceCollection {
         if exclusive_class != 0 {
             for i in 0..self.active_voice_count {
                 let voice = &self.voices[i];
-                if voice.exclusive_class == exclusive_class && voice.channel == channel {
+                if voice.get_exclusive_class() == exclusive_class && voice.get_channel() == channel
+                {
                     return Some(&mut self.voices[i]);
                 }
             }
@@ -62,7 +63,7 @@ impl VoiceCollection {
             } else if priority == lowest_priority {
                 // Same priority...
                 // The older one should be more suitable for reuse.
-                if voice.voice_length > self.voices[candidate].voice_length {
+                if voice.get_samples_elapsed() > self.voices[candidate].get_samples_elapsed() {
                     candidate = i;
                 }
             }

--- a/rustysynth/src/voice_collection.rs
+++ b/rustysynth/src/voice_collection.rs
@@ -36,7 +36,7 @@ impl VoiceCollection {
         if exclusive_class != 0 {
             for i in 0..self.active_voice_count {
                 let voice = &self.voices[i];
-                if voice.get_exclusive_class() == exclusive_class && voice.get_channel() == channel
+                if voice.exclusive_class() == exclusive_class && voice.channel() == channel
                 {
                     return Some(&mut self.voices[i]);
                 }
@@ -56,14 +56,14 @@ impl VoiceCollection {
         let mut lowest_priority = f32::MAX;
         for i in 0..self.active_voice_count {
             let voice = &self.voices[i];
-            let priority = voice.get_priority();
+            let priority = voice.priority();
             if priority < lowest_priority {
                 lowest_priority = priority;
                 candidate = i;
             } else if priority == lowest_priority {
                 // Same priority...
                 // The older one should be more suitable for reuse.
-                if voice.get_voice_length() > self.voices[candidate].get_voice_length() {
+                if voice.voice_length() > self.voices[candidate].voice_length() {
                     candidate = i;
                 }
             }

--- a/rustysynth/src/voice_collection.rs
+++ b/rustysynth/src/voice_collection.rs
@@ -63,7 +63,7 @@ impl VoiceCollection {
             } else if priority == lowest_priority {
                 // Same priority...
                 // The older one should be more suitable for reuse.
-                if voice.get_samples_elapsed() > self.voices[candidate].get_samples_elapsed() {
+                if voice.get_voice_length() > self.voices[candidate].get_voice_length() {
                     candidate = i;
                 }
             }


### PR DESCRIPTION
**Changes:**

- `VoiceState` is an enum
- Replaced `block_size` with `self.block.len()`
- Removed unused `sample_rate`
- Renamed `voice_length` to `samples_elapsed`
- Made some public fields that were only used immutably private and provided getters for immutable access instead.

**Notes:**

I didn't make any unsolicited changes to the style, but I would personally replace this

```rust
    pub(crate) fn get_block(&self) -> &Vec<f32> {
        &self.block
    }

    pub(crate) fn get_samples_elapsed(&self) -> usize {
        self.samples_elapsed
    }

    pub(crate) fn get_exclusive_class(&self) -> i32 {
        self.exclusive_class
    }

    pub(crate) fn get_channel(&self) -> i32 {
        self.channel
    }

    pub(crate) fn get_key(&self) -> i32 {
        self.key
    }
    // ...
```
with this:
```rust
    pub fn block(&self) -> &Vec<f32> {
        &self.block
    }

    pub fn samples_elapsed(&self) -> usize {
        self.samples_elapsed
    }

    pub fn exclusive_class(&self) -> i32 {
        self.exclusive_class
    }

    pub fn channel(&self) -> i32 {
        self.channel
    }

    pub fn key(&self) -> i32 {
        self.key
    }
    // ...
```