### PR TITLE
refactor: soundfont_sampledata.rs

### DIFF
--- a/rustysynth/src/soundfont.rs
+++ b/rustysynth/src/soundfont.rs
@@ -52,7 +52,7 @@ impl SoundFont {
 
         let sound_font = Self {
             info,
-            bits_per_sample: 16,
+            bits_per_sample: sample_data.bits_per_sample,
             wave_data: sample_data.wave_data,
             sample_headers: parameters.sample_headers,
             presets: parameters.presets,


### PR DESCRIPTION
I read through soundfont_sampledata.rs and the usages of the struct.

- A small amount of code cleanup
- Reduced wave_data length check to 2, because the stride is 2 bytes and not 1.
- `bits_per_sample` was unused. This wouldn't have surfaced until 24-bit was implemented, but fixed anyway.