### PR TITLE
Avoid panic with invalid looped sample in SF2

### DIFF
--- a/rustysynth/src/oscillator.rs
+++ b/rustysynth/src/oscillator.rs
@@ -78,7 +78,7 @@ impl Oscillator {
         self.tune = coarse_tune as f32 + 0.01_f32 * fine_tune as f32;
         self.pitch_change_scale = 0.01_f32 * scale_tuning as f32;
         self.sample_rate_ratio = sample_rate as f32 / self.synthesizer_sample_rate as f32;
-        self.looping = self.loop_mode != LoopMode::NoLoop;
+        self.looping = self.loop_mode != LoopMode::NoLoop && self.start_loop < self.end_loop;
         self.position_fp = (start as i64) << Oscillator::FRAC_BITS;
     }
 

--- a/rustysynth/src/oscillator.rs
+++ b/rustysynth/src/oscillator.rs
@@ -78,7 +78,7 @@ impl Oscillator {
         self.tune = coarse_tune as f32 + 0.01_f32 * fine_tune as f32;
         self.pitch_change_scale = 0.01_f32 * scale_tuning as f32;
         self.sample_rate_ratio = sample_rate as f32 / self.synthesizer_sample_rate as f32;
-        self.looping = self.loop_mode != LoopMode::NoLoop && self.start_loop < self.end_loop;
+        self.looping = self.loop_mode != LoopMode::NoLoop;
         self.position_fp = (start as i64) << Oscillator::FRAC_BITS;
     }
 

--- a/rustysynth/src/soundfont.rs
+++ b/rustysynth/src/soundfont.rs
@@ -11,6 +11,7 @@ use crate::sample_header::SampleHeader;
 use crate::soundfont_info::SoundFontInfo;
 use crate::soundfont_parameters::SoundFontParameters;
 use crate::soundfont_sampledata::SoundFontSampleData;
+use crate::LoopMode;
 
 /// Reperesents a SoundFont.
 #[derive(Debug)]
@@ -73,6 +74,7 @@ impl SoundFont {
                 let end = region.get_sample_end();
                 let start_loop = region.get_sample_start_loop();
                 let end_loop = region.get_sample_end_loop();
+                let loop_mode = region.get_sample_modes();
 
                 if start < 0
                     || start_loop < 0
@@ -80,6 +82,7 @@ impl SoundFont {
                     || end_loop as usize >= self.wave_data.len()
                     || end <= start
                     || end_loop < start_loop
+                    || (loop_mode != LoopMode::NoLoop && start_loop >= end_loop)
                 {
                     return Err(SoundFontError::SanityCheckFailed);
                 }


### PR DESCRIPTION
I have a SF2 that I created with Polyphone with the characteristic that the Instrument's "Loop playback" flag is set to "Loop Until Note Off" -- though the actual enum likely doesn't matter -- but no Loop Start / End are defined. 

[example.zip](https://github.com/user-attachments/files/21702413/example.zip)

This condition seems to violate the SoundFont spec (v2.01). Regardless, when using this SoundFont to play a note, the playback proceeds through the end of the sample memory and I get a panic:

```
thread '<unnamed>' panicked at .../rustysynth/rustysynth/src/oscillator.rs:155:22:
index out of bounds: the len is 29370 but the index is 29370
```

The logic in `Oscillator::fill_block_continuous` tries to adjust the position backward by the loop length, but since the loop is empty, the `position_fp` just keeps incrementing until the panic.

(It seems the same issue will affect `meltysynth` as well, but I don't use C# at the moment.)

I think the immediate fix is as simple as the check in this PR and has no runtime cost. But I will leave it to you to decide if there are better ways to avoid this problem. 
