### PR TITLE
Add optional sf3 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Added optional SoundFont3 (SF3) support behind the `sf3` feature
+
 # v1.3.6
 
 - Various code clean-ups ([thanks to @sevonj](https://github.com/sinshu/rustysynth/issues/42)).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ RustySynth is a SoundFont MIDI synthesizer written in pure Rust, ported from [Me
 
 * Suitable for both real-time and offline synthesis.
 * Supports standard MIDI files with additional features including dynamic tempo changing.
-* No dependencies other than the standard library.
+* No dependencies other than the standard library (SF2). Optional SoundFont3 (SF3) support via the `sf3` feature.
 
 
 
@@ -28,6 +28,12 @@ RustySynth is available on [crates.io](https://crates.io/crates/rustysynth):
 
 ```
 cargo add rustysynth
+```
+
+To load SoundFont3 (SF3) files (Ogg-Vorbis-compressed samples), enable the optional `sf3` feature:
+
+```
+cargo add rustysynth --features sf3
 ```
 
 

--- a/rustysynth/Cargo.toml
+++ b/rustysynth/Cargo.toml
@@ -12,4 +12,8 @@ license = "MIT"
 keywords = ["soundfont", "midi", "synthesizer", "audio", "music"]
 categories = ["multimedia::audio"]
 
+[features]
+sf3 = ["dep:lewton"]
+
 [dependencies]
+lewton = { version = "0.10", optional = true }

--- a/rustysynth/README.md
+++ b/rustysynth/README.md
@@ -8,7 +8,18 @@ RustySynth is a SoundFont MIDI synthesizer written in pure Rust, ported from [Me
 
 * Suitable for both real-time and offline synthesis.
 * Supports standard MIDI files with additional features including dynamic tempo changing.
-* No dependencies other than the standard library.
+* No dependencies other than the standard library (SF2). Optional SoundFont3 (SF3) support via the `sf3` feature.
+
+## SoundFont3 (SF3)
+
+SF3 SoundFonts use Ogg-Vorbis-compressed samples. Support is opt-in (it adds the
+[`lewton`](https://crates.io/crates/lewton) dependency):
+
+```
+cargo add rustysynth --features sf3
+```
+
+With the feature enabled, `SoundFont::new` loads SF3 files transparently.
 
 
 

--- a/rustysynth/src/binary_reader.rs
+++ b/rustysynth/src/binary_reader.rs
@@ -3,7 +3,6 @@
 use std::io;
 use std::io::ErrorKind;
 use std::io::Read;
-use std::slice;
 use std::str;
 
 use crate::four_cc::FourCC;
@@ -120,17 +119,9 @@ impl BinaryReader {
         reader.read_exact(&mut data)
     }
 
-    pub(crate) fn read_wave_data<R: Read>(
-        reader: &mut R,
-        size: usize,
-    ) -> Result<Vec<i16>, io::Error> {
-        let length = size / 2;
-        let mut samples: Vec<i16> = vec![0; length];
-
-        let ptr = samples.as_mut_ptr() as *mut u8;
-        let data = unsafe { slice::from_raw_parts_mut(ptr, size) };
-        reader.read_exact(data)?;
-
-        Ok(samples)
+    pub(crate) fn read_bytes<R: Read>(reader: &mut R, size: usize) -> Result<Vec<u8>, io::Error> {
+        let mut data: Vec<u8> = vec![0; size];
+        reader.read_exact(&mut data)?;
+        Ok(data)
     }
 }

--- a/rustysynth/src/error.rs
+++ b/rustysynth/src/error.rs
@@ -57,6 +57,7 @@ pub enum SoundFontError {
     ListContainsUnknownId(FourCC),
     SampleDataNotFound,
     UnsupportedSampleFormat,
+    Sf3DecodeFailed(String),
     SubChunkNotFound(FourCC),
     InvalidPresetList,
     InvalidInstrumentId {
@@ -108,7 +109,13 @@ impl fmt::Display for SoundFontError {
                 write!(f, "the INFO list contains an unknown ID '{id}'")
             }
             SoundFontError::SampleDataNotFound => write!(f, "no valid sample data was found"),
-            SoundFontError::UnsupportedSampleFormat => write!(f, "SoundFont3 is not yet supported"),
+            SoundFontError::UnsupportedSampleFormat => write!(
+                f,
+                "SoundFont3 is not supported; rebuild rustysynth with the 'sf3' feature enabled"
+            ),
+            SoundFontError::Sf3DecodeFailed(msg) => {
+                write!(f, "failed to decode SoundFont3 sample data: {msg}")
+            }
             SoundFontError::SubChunkNotFound(id) => {
                 write!(f, "the '{}' sub-chunk was not found", id)
             }

--- a/rustysynth/src/lib.rs
+++ b/rustysynth/src/lib.rs
@@ -16,6 +16,8 @@ mod preset_info;
 mod preset_region;
 mod sample_header;
 mod soundfont;
+#[cfg(feature = "sf3")]
+mod soundfont3;
 mod soundfont_info;
 mod soundfont_math;
 mod soundfont_parameters;

--- a/rustysynth/src/soundfont.rs
+++ b/rustysynth/src/soundfont.rs
@@ -49,12 +49,12 @@ impl SoundFont {
 
         let info = SoundFontInfo::new(reader)?;
         let sample_data = SoundFontSampleData::new(reader)?;
-        let parameters = SoundFontParameters::new(reader)?;
+        let parameters = SoundFontParameters::new(reader, sample_data)?;
 
         let sound_font = Self {
             info,
-            bits_per_sample: sample_data.bits_per_sample,
-            wave_data: sample_data.wave_data,
+            bits_per_sample: parameters.bits_per_sample,
+            wave_data: parameters.wave_data,
             sample_headers: parameters.sample_headers,
             presets: parameters.presets,
             instruments: parameters.instruments,
@@ -137,6 +137,7 @@ mod tests {
             .join("samples")
     }
 
+    #[cfg(not(feature = "sf3"))]
     #[test]
     fn test_load_reject_sf3() {
         let path = samples_dir_path().join("dummy.sf3");
@@ -145,6 +146,17 @@ mod tests {
             SoundFont::new(&mut file),
             Err(SoundFontError::UnsupportedSampleFormat)
         ));
+    }
+
+    #[cfg(feature = "sf3")]
+    #[test]
+    fn test_load_sf3() {
+        let path = samples_dir_path().join("dummy.sf3");
+        let mut file = File::open(&path).unwrap();
+        let sf = SoundFont::new(&mut file).unwrap();
+        assert_eq!(sf.get_bits_per_sample(), 16);
+        assert!(!sf.get_wave_data().is_empty());
+        assert!(!sf.get_sample_headers().is_empty());
     }
 
     // smpl sub-chunk exists, but is zero-length.

--- a/rustysynth/src/soundfont3.rs
+++ b/rustysynth/src/soundfont3.rs
@@ -1,0 +1,144 @@
+#![allow(dead_code)]
+
+use std::io::Cursor;
+
+use lewton::inside_ogg::OggStreamReader;
+
+use crate::error::SoundFontError;
+use crate::sample_header::SampleHeader;
+
+/// Number of zero-valued guard frames appended after each decoded sample.
+///
+/// The SoundFont specification requires at least 46 zero sample-points after
+/// each sample. They keep the oscillator's `data[index + 1]` interpolation
+/// reads and the loader's sanity check in bounds, and stop one sample's tail
+/// from reading into the next.
+const GUARD_FRAMES: usize = 46;
+
+/// Decodes the Ogg Vorbis sample streams of a SoundFont3 `smpl` chunk into a
+/// single 16-bit PCM pool and rewrites each sample header to index that pool.
+pub(crate) fn decode_vorbis_samples(
+    smpl: &[u8],
+    sample_headers: &mut [SampleHeader],
+) -> Result<Vec<i16>, SoundFontError> {
+    let mut wave_data: Vec<i16> = Vec::new();
+
+    for header in sample_headers.iter_mut() {
+        // In SF3, start/end are byte offsets of this sample's Ogg stream.
+        let start = header.start;
+        let end = header.end;
+        if start < 0 || end < start || end as usize > smpl.len() {
+            return Err(SoundFontError::Sf3DecodeFailed(format!(
+                "sample '{}' has an invalid byte range {start}..{end}",
+                header.name
+            )));
+        }
+
+        let pcm = decode_mono_stream(&smpl[start as usize..end as usize])?;
+
+        let offset = wave_data.len() as i32;
+        let frames = pcm.len() as i32;
+
+        wave_data.extend_from_slice(&pcm);
+        wave_data.resize(wave_data.len() + GUARD_FRAMES, 0);
+
+        // Rewrite the header to index the decoded pool. start_loop/end_loop were
+        // sample-frame indices into this sample's own decoded PCM.
+        header.start = offset;
+        header.end = offset + frames;
+        header.start_loop += offset;
+        header.end_loop += offset;
+    }
+
+    Ok(wave_data)
+}
+
+fn decode_mono_stream(stream: &[u8]) -> Result<Vec<i16>, SoundFontError> {
+    let mut reader = OggStreamReader::new(Cursor::new(stream))
+        .map_err(|e| SoundFontError::Sf3DecodeFailed(e.to_string()))?;
+
+    if reader.ident_hdr.audio_channels != 1 {
+        return Err(SoundFontError::Sf3DecodeFailed(format!(
+            "expected a mono sample, but found {} channels",
+            reader.ident_hdr.audio_channels
+        )));
+    }
+
+    let mut pcm: Vec<i16> = Vec::new();
+    while let Some(packet) = reader
+        .read_dec_packet()
+        .map_err(|e| SoundFontError::Sf3DecodeFailed(e.to_string()))?
+    {
+        // Mono: channel 0 is the whole sample.
+        pcm.extend_from_slice(&packet[0]);
+    }
+
+    Ok(pcm)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn u32_le(bytes: &[u8], offset: usize) -> u32 {
+        u32::from_le_bytes([
+            bytes[offset],
+            bytes[offset + 1],
+            bytes[offset + 2],
+            bytes[offset + 3],
+        ])
+    }
+
+    fn find_chunk(bytes: &[u8], id: &[u8]) -> usize {
+        bytes
+            .windows(id.len())
+            .position(|w| w == id)
+            .expect("chunk id not found in dummy.sf3")
+    }
+
+    #[test]
+    fn decodes_first_sample_of_dummy_sf3() {
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.pop();
+        path.push("samples");
+        path.push("dummy.sf3");
+        let bytes = fs::read(&path).unwrap();
+
+        // smpl sub-chunk: 4-byte id, 4-byte LE size, then the raw Ogg stream(s).
+        let smpl_pos = find_chunk(&bytes, b"smpl");
+        let smpl_size = u32_le(&bytes, smpl_pos + 4) as usize;
+        let smpl = &bytes[smpl_pos + 8..smpl_pos + 8 + smpl_size];
+
+        // shdr sub-chunk: 46-byte SampleHeader records.
+        // dwStart @ +20, dwEnd @ +24, dwStartloop @ +28, dwEndloop @ +32.
+        let shdr_pos = find_chunk(&bytes, b"shdr");
+        let rec = shdr_pos + 8;
+        let start = u32_le(&bytes, rec + 20) as i32;
+        let end = u32_le(&bytes, rec + 24) as i32;
+        let start_loop = u32_le(&bytes, rec + 28) as i32;
+        let end_loop = u32_le(&bytes, rec + 32) as i32;
+
+        let mut headers = vec![SampleHeader {
+            name: String::from("dummy"),
+            start,
+            end,
+            start_loop,
+            end_loop,
+            sample_rate: 44100,
+            original_pitch: 60,
+            pitch_correction: 0,
+            link: 0,
+            sample_type: 1,
+        }];
+
+        let wave = decode_vorbis_samples(smpl, &mut headers).unwrap();
+
+        assert!(!wave.is_empty(), "decoded PCM pool should not be empty");
+        assert_eq!(headers[0].start, 0, "first sample starts at pool offset 0");
+        assert!(headers[0].end > 0);
+        assert!(headers[0].end as usize <= wave.len());
+        assert!(headers[0].end_loop as usize <= wave.len());
+    }
+}

--- a/rustysynth/src/soundfont_parameters.rs
+++ b/rustysynth/src/soundfont_parameters.rs
@@ -12,18 +12,24 @@ use crate::preset::Preset;
 use crate::preset_info::PresetInfo;
 use crate::read_counter::ReadCounter;
 use crate::sample_header::SampleHeader;
+use crate::soundfont_sampledata::SoundFontSampleData;
 use crate::zone::Zone;
 use crate::zone_info::ZoneInfo;
 
 #[non_exhaustive]
 pub(crate) struct SoundFontParameters {
+    pub(crate) bits_per_sample: i32,
+    pub(crate) wave_data: Vec<i16>,
     pub(crate) sample_headers: Vec<SampleHeader>,
     pub(crate) presets: Vec<Preset>,
     pub(crate) instruments: Vec<Instrument>,
 }
 
 impl SoundFontParameters {
-    pub(crate) fn new<R: Read>(reader: &mut R) -> Result<Self, SoundFontError> {
+    pub(crate) fn new<R: Read>(
+        reader: &mut R,
+        sample_data: SoundFontSampleData,
+    ) -> Result<Self, SoundFontError> {
         let chunk_id = BinaryReader::read_four_cc(reader)?;
         if chunk_id != b"LIST" {
             return Err(SoundFontError::ListChunkNotFound);
@@ -90,9 +96,22 @@ impl SoundFontParameters {
             SoundFontError::SubChunkNotFound(FourCC::from_bytes(*b"IGEN")),
         )?;
 
-        let sample_headers = sample_headers.ok_or(SoundFontError::SubChunkNotFound(
+        #[cfg_attr(not(feature = "sf3"), allow(unused_mut))]
+        let mut sample_headers = sample_headers.ok_or(SoundFontError::SubChunkNotFound(
             FourCC::from_bytes(*b"SHDR"),
         ))?;
+
+        let (bits_per_sample, wave_data) = match sample_data {
+            SoundFontSampleData::Pcm {
+                bits_per_sample,
+                wave_data,
+            } => (bits_per_sample, wave_data),
+            #[cfg(feature = "sf3")]
+            SoundFontSampleData::Vorbis(smpl) => (
+                16,
+                crate::soundfont3::decode_vorbis_samples(&smpl, &mut sample_headers)?,
+            ),
+        };
 
         let instrument_zones = Zone::create(&instrument_bag, &instrument_generators)?;
         let instruments =
@@ -102,6 +121,8 @@ impl SoundFontParameters {
         let presets = Preset::create(&preset_infos, &preset_zones, &instruments)?;
 
         Ok(Self {
+            bits_per_sample,
+            wave_data,
             sample_headers,
             presets,
             instruments,

--- a/rustysynth/src/soundfont_sampledata.rs
+++ b/rustysynth/src/soundfont_sampledata.rs
@@ -7,10 +7,16 @@ use crate::error::SoundFontError;
 use crate::four_cc::FourCC;
 use crate::read_counter::ReadCounter;
 
-#[non_exhaustive]
-pub(crate) struct SoundFontSampleData {
-    pub bits_per_sample: i32,
-    pub wave_data: Vec<i16>,
+/// The sample data (`sdta`) of a SoundFont, classified by encoding.
+pub(crate) enum SoundFontSampleData {
+    /// SoundFont2: raw little-endian 16-bit PCM, ready for playback.
+    Pcm {
+        bits_per_sample: i32,
+        wave_data: Vec<i16>,
+    },
+    /// SoundFont3: the concatenated per-sample Ogg Vorbis streams from `smpl`.
+    #[cfg(feature = "sf3")]
+    Vorbis(Vec<u8>),
 }
 
 impl SoundFontSampleData {
@@ -31,36 +37,46 @@ impl SoundFontSampleData {
             });
         }
 
-        let mut wave_data: Option<Vec<i16>> = None;
+        let mut sample_data: Option<Vec<u8>> = None;
 
         while reader.bytes_read() < end {
             let id = BinaryReader::read_four_cc(reader)?;
             let size = BinaryReader::read_u32(reader)? as usize;
 
             match id.as_bytes() {
-                b"smpl" => wave_data = Some(BinaryReader::read_wave_data(reader, size)?),
+                b"smpl" => sample_data = Some(BinaryReader::read_bytes(reader, size)?),
                 b"sm24" => BinaryReader::discard_data(reader, size)?,
                 _ => return Err(SoundFontError::ListContainsUnknownId(id)),
             }
         }
 
-        let Some(wave_data) = wave_data else {
+        let Some(sample_data) = sample_data else {
             return Err(SoundFontError::SampleDataNotFound);
         };
 
-        if wave_data.len() < 2 {
+        if sample_data.len() < 2 {
             return Err(SoundFontError::SampleDataNotFound);
         }
 
-        // SoundFont3 compressed sample format
-        let four_cc = unsafe { std::slice::from_raw_parts(wave_data.as_ptr() as *const u8, 4) };
-        if four_cc == b"OggS" {
+        // SoundFont3 stores Ogg Vorbis streams (RIFF "OggS" magic) in `smpl`.
+        if sample_data.starts_with(b"OggS") {
+            #[cfg(feature = "sf3")]
+            return Ok(SoundFontSampleData::Vorbis(sample_data));
+            #[cfg(not(feature = "sf3"))]
             return Err(SoundFontError::UnsupportedSampleFormat);
         }
 
-        Ok(Self {
+        Ok(SoundFontSampleData::Pcm {
             bits_per_sample: 16,
-            wave_data,
+            wave_data: bytes_to_i16(&sample_data),
         })
     }
+}
+
+/// Reinterprets a little-endian byte buffer as 16-bit PCM samples.
+fn bytes_to_i16(bytes: &[u8]) -> Vec<i16> {
+    bytes
+        .chunks_exact(2)
+        .map(|c| i16::from_le_bytes([c[0], c[1]]))
+        .collect()
 }


### PR DESCRIPTION
Add opt-in SF3 support behind a new `sf3` feature, which uses the optional `lewton` to decode Ogg Vorbis samples. Unit and integration tests are included.

Tested with [FluidR3Mono_GM.sf3](https://github.com/musescore/MuseScore/raw/2.1/share/sound/FluidR3Mono_GM.sf3), and works as expected. This is a huge improvement for web apps or bandwidth/storage-limited embedded devices, as the size of sf3 is almost 10 times smaller.